### PR TITLE
グループ，グループ作成フォームの追加

### DIFF
--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -16,7 +16,7 @@ const schema = yup.object().shape({
 });
 
 export const CreateGroupForm = (): JSX.Element => {
-  const { user } = useContext(AuthContext);
+  const { authUser } = useContext(AuthContext);
   const {
     register,
     handleSubmit,
@@ -30,14 +30,14 @@ export const CreateGroupForm = (): JSX.Element => {
     });
   };
   const createGroup = async (data: InputsType) => {
-    if (user != null) {
+    if (authUser != null) {
       const group: Group = {
         name: data["name"],
         members: {
-          [user.uid]: true,
+          [authUser.uid]: true,
         },
       };
-      storeGroup(group, user.uid)
+      storeGroup(group, authUser.uid)
         .then(() => {
           Router.push("/");
         })

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -39,7 +39,7 @@ export const CreateGroupForm = (): JSX.Element => {
       };
       storeGroup(group, user.uid)
         .then(() => {
-          Router.push("/calendar");
+          Router.push("/");
         })
         .catch(() => {
           setUnexpectedError();

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -1,0 +1,72 @@
+import { useForm } from "react-hook-form";
+import { Form, Button } from "react-bootstrap";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import Router from "next/router";
+import React, { useContext } from "react";
+import { AuthContext } from "../context/AuthContext";
+import { Group, storeGroup } from "../interfaces/Group";
+
+type InputsType = {
+  name: string;
+};
+
+const schema = yup.object().shape({
+  name: yup.string().required("名前は必須です"),
+});
+
+export const CreateGroupForm = (): JSX.Element => {
+  const { user } = useContext(AuthContext);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<InputsType>({ resolver: yupResolver(schema) });
+  const setUnexpectedError = () => {
+    setError("name", {
+      type: "manual",
+      message: "予期せぬエラーが発生しました！ もう一度お試しください",
+    });
+  };
+  const createGroup = async (data: InputsType) => {
+    if (user != null) {
+      const group: Group = {
+        name: data["name"],
+        members: {
+          [user.uid]: true,
+        },
+      };
+      storeGroup(group, user.uid)
+        .then(() => {
+          Router.push("/calendar");
+        })
+        .catch(() => {
+          setUnexpectedError();
+        });
+    } else {
+      setUnexpectedError();
+    }
+  };
+  return (
+    <Form onSubmit={handleSubmit(createGroup)}>
+      <Form.Group>
+        <Form.Label>Group Name</Form.Label>
+        <Form.Control
+          type="name"
+          isInvalid={!!errors.name}
+          {...register("name")}
+        />
+        {errors.name && (
+          <Form.Control.Feedback type="invalid">
+            {errors.name.message}
+          </Form.Control.Feedback>
+        )}
+      </Form.Group>
+
+      <Button variant="accent" type="submit">
+        作成
+      </Button>
+    </Form>
+  );
+};

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -29,10 +29,8 @@ export const GroupCalendar = ({
         );
         if (index == -1) {
           dateToFreeNumList.push({ date: dateStatus.date, num: 1 });
-          console.log(dateToFreeNumList);
         } else {
           dateToFreeNumList[index].num += 1;
-          console.log(dateToFreeNumList);
         }
       }
     }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -36,14 +36,14 @@ const Layout = ({ children, title = "Default Title" }: Props): JSX.Element => {
           <Link href="/" passHref>
             <Navbar.Brand className="mr-auto">Hima Share</Navbar.Brand>
           </Link>
-          {authContext.user && (
+          {authContext.authUser && (
             <Nav>
               <Nav.Link active onClick={logout}>
                 Logout
               </Nav.Link>
             </Nav>
           )}
-          {!authContext.user && (
+          {!authContext.authUser && (
             <Nav>
               <Link href="/login" passHref>
                 <Nav.Link active>Login</Nav.Link>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -78,6 +78,7 @@ export const RegisterForm = (): JSX.Element => {
           const user: User = {
             name: data["userName"],
             email: data["email"],
+            groups: {},
           };
           storeUser(user, uid)
             .then(() => {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -2,9 +2,9 @@ import { createContext } from "react";
 import firebase from "firebase/app";
 
 export const AuthContext = createContext<{
-  user: firebase.User | null;
+  authUser: firebase.User | null;
   isLoading: boolean;
 }>({
-  user: null,
+  authUser: null,
   isLoading: true,
 });

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -2,9 +2,7 @@ import { createContext } from "react";
 import firebase from "firebase/app";
 
 export const AuthContext = createContext<{
-  authUser: firebase.User | null;
-  isLoading: boolean;
+  authUser: firebase.User | null | undefined;
 }>({
-  authUser: null,
-  isLoading: true,
+  authUser: undefined,
 });

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -35,12 +35,7 @@ export const storeDateStatusList = async (
   uid: string
 ): Promise<void> => {
   const data = toFormatData(dateStatusList);
-  return db
-    .ref(`calendars/${uid}`)
-    .set(data)
-    .catch(() => {
-      return Promise.reject<void>("Database Error!");
-    });
+  return db.ref(`calendars/${uid}`).set(data);
 };
 
 export const loadDateStatusList = async (
@@ -59,9 +54,7 @@ export const loadDateStatusList = async (
       } else {
         return null;
       }
-    })
-    .catch(() => {
-      return Promise.reject<null>("Database Error!");
     });
+
   return data;
 };

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -1,6 +1,7 @@
 import { db } from "../utils/firebase";
 import { joinGroup } from "./User";
 
+// TODO membersが空にならないようにする．空だたfirebaseには保存されずundefined扱い
 export interface Group {
   name: string;
   members: {

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -1,0 +1,18 @@
+import { db } from "../utils/firebase";
+import { joinGroup } from "./User";
+
+export interface Group {
+  name: string;
+  members: {
+    [uid: string]: true;
+  };
+}
+
+export const storeGroup = (group: Group, uid: string): Promise<void> => {
+  const groupId = db.ref().child("groups").push(group).key;
+  if (groupId == null) {
+    return Promise.reject("GroupId is null");
+  } else {
+    return joinGroup(uid, groupId);
+  }
+};

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -8,6 +8,10 @@ export interface Group {
   };
 }
 
+export interface GroupWithId extends Group {
+  id: string;
+}
+
 export const storeGroup = (group: Group, uid: string): Promise<void> => {
   const groupId = db.ref().child("groups").push(group).key;
   if (groupId == null) {
@@ -15,4 +19,22 @@ export const storeGroup = (group: Group, uid: string): Promise<void> => {
   } else {
     return joinGroup(uid, groupId);
   }
+};
+
+export const loadGroup = (groupId: string): Promise<GroupWithId | null> => {
+  const groupWithId = db
+    .ref()
+    .child("groups")
+    .child(groupId)
+    .get()
+    .then((snapShot) => {
+      if (snapShot.exists()) {
+        const group = snapShot.val() as Group;
+        return { ...group, id: groupId };
+      } else {
+        return null;
+      }
+    });
+
+  return groupWithId;
 };

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -4,7 +4,7 @@ export interface User {
   name: string;
   email: string;
   groups: {
-    [key: string]: true;
+    [groupId: string]: true;
   };
 }
 

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -8,6 +8,8 @@ export interface User {
   };
 }
 
+// TODO 必要になればUserWithIdを作る
+
 export const storeUser = (user: User, uid: string): Promise<void> => {
   return db.ref(`users/${uid}`).set(user);
 };
@@ -20,7 +22,11 @@ export const loadUser = (uid: string): Promise<User | null> => {
     .get()
     .then((snapShot) => {
       if (snapShot.exists()) {
-        return snapShot.val() as User;
+        const u = snapShot.val();
+        if (u.groups == null) {
+          u["groups"] = {};
+        }
+        return u as User;
       } else {
         return null;
       }

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -3,15 +3,13 @@ import { db } from "../utils/firebase";
 export interface User {
   name: string;
   email: string;
+  groups: {
+    [key: string]: true;
+  };
 }
 
-export const storeUser = async (user: User, uid: string): Promise<void> => {
-  return db
-    .ref(`users/${uid}`)
-    .set(user)
-    .catch(() => {
-      return Promise.reject<void>("Database Error!");
-    });
+export const storeUser = (user: User, uid: string): Promise<void> => {
+  return db.ref(`users/${uid}`).set(user);
 };
 
 export const loadUser = (uid: string): Promise<User | null> => {
@@ -26,9 +24,11 @@ export const loadUser = (uid: string): Promise<User | null> => {
       } else {
         return null;
       }
-    })
-    .catch(() => {
-      return Promise.reject<null>("Database Error!");
     });
+
   return user;
+};
+
+export const joinGroup = (uid: string, groupId: string): Promise<void> => {
+  return db.ref(`users/${uid}/groups`).set({ [groupId]: true });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,17 +10,17 @@ import "../styles/sass/bootstrap-custom.scss";
 import "../styles/sass/calendar.scss";
 
 const MyApp = ({ Component, pageProps }: AppProps): JSX.Element => {
-  const [user, setUser] = useState<firebase.User | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [authUser, setAuthUser] = useState<firebase.User | null | undefined>(
+    undefined
+  );
   useEffect(() => {
     auth.onAuthStateChanged((u) => {
-      setUser(u);
-      setIsLoading(false);
+      setAuthUser(u);
     });
   }, []);
 
   return (
-    <AuthContext.Provider value={{ authUser: user, isLoading }}>
+    <AuthContext.Provider value={{ authUser }}>
       <Component {...pageProps} />
     </AuthContext.Provider>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,7 @@ const MyApp = ({ Component, pageProps }: AppProps): JSX.Element => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, isLoading }}>
+    <AuthContext.Provider value={{ authUser: user, isLoading }}>
       <Component {...pageProps} />
     </AuthContext.Provider>
   );

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -12,17 +12,17 @@ import {
 } from "../interfaces/DateStatus";
 
 const UserCalendarPage = (): JSX.Element => {
-  const { user, isLoading } = useContext(AuthContext);
+  const { authUser, isLoading } = useContext(AuthContext);
   const [dateStatusList, setDateStatusList] = useState<DateStatus[]>([]);
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
     let unmounted = false;
     const setFromDatabase = async () => {
-      if (user == null) {
+      if (authUser == null) {
         Router.push("/login");
       } else {
         // TODO エラー処理
-        const data = await loadDateStatusList(user.uid);
+        const data = await loadDateStatusList(authUser.uid);
         if (data != null && !unmounted) {
           setDateStatusList(data);
         }
@@ -38,11 +38,11 @@ const UserCalendarPage = (): JSX.Element => {
   }, [isLoading]);
   useEffect(() => {
     const setToDatabase = async () => {
-      if (user == null) {
+      if (authUser == null) {
         Router.push("/login");
       } else {
         // TODO エラー処理
-        await storeDateStatusList(dateStatusList, user.uid);
+        await storeDateStatusList(dateStatusList, authUser.uid);
       }
     };
     if (!isLoading) {
@@ -51,7 +51,7 @@ const UserCalendarPage = (): JSX.Element => {
   }, [dateStatusList]);
   return (
     <React.Fragment>
-      {user && (
+      {authUser && (
         <Layout title="カレンダー入力">
           <h1>カレンダー入力</h1>
           <p>カレンダーに予定を設定しよう！</p>

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -12,7 +12,7 @@ import {
 } from "../interfaces/DateStatus";
 
 const UserCalendarPage = (): JSX.Element => {
-  const { authUser, isLoading } = useContext(AuthContext);
+  const { authUser } = useContext(AuthContext);
   const [dateStatusList, setDateStatusList] = useState<DateStatus[]>([]);
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
@@ -28,14 +28,14 @@ const UserCalendarPage = (): JSX.Element => {
         }
       }
     };
-    if (!isLoading) {
+    if (authUser !== undefined) {
       setFromDatabase();
     }
     const cleanup = () => {
       unmounted = true;
     };
     return cleanup;
-  }, [isLoading]);
+  }, [authUser]);
   useEffect(() => {
     const setToDatabase = async () => {
       if (authUser == null) {
@@ -45,7 +45,7 @@ const UserCalendarPage = (): JSX.Element => {
         await storeDateStatusList(dateStatusList, authUser.uid);
       }
     };
-    if (!isLoading) {
+    if (authUser !== undefined) {
       setToDatabase();
     }
   }, [dateStatusList]);

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Router from "next/router";
+import React from "react";
 import { useContext, useEffect, useState } from "react";
 import Layout from "../components/Layout";
 import { UserCalendar } from "../components/UserCalendar";
@@ -11,8 +12,7 @@ import {
 } from "../interfaces/DateStatus";
 
 const UserCalendarPage = (): JSX.Element => {
-  const authContext = useContext(AuthContext);
-  const { user, isLoading } = authContext;
+  const { user, isLoading } = useContext(AuthContext);
   const [dateStatusList, setDateStatusList] = useState<DateStatus[]>([]);
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
@@ -50,19 +50,23 @@ const UserCalendarPage = (): JSX.Element => {
     }
   }, [dateStatusList]);
   return (
-    <Layout title="カレンダー入力">
-      <h1>カレンダー入力</h1>
-      <p>カレンダーに予定を設定しよう！</p>
-      <UserCalendar
-        dateStatusList={dateStatusList}
-        setDateStatusList={(list) => setDateStatusList(list)}
-      />
-      <p>
-        <Link href="/">
-          <a>ホーム</a>
-        </Link>
-      </p>
-    </Layout>
+    <React.Fragment>
+      {user && (
+        <Layout title="カレンダー入力">
+          <h1>カレンダー入力</h1>
+          <p>カレンダーに予定を設定しよう！</p>
+          <UserCalendar
+            dateStatusList={dateStatusList}
+            setDateStatusList={(list) => setDateStatusList(list)}
+          />
+          <p>
+            <Link href="/">
+              <a>ホーム</a>
+            </Link>
+          </p>
+        </Layout>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -6,15 +6,15 @@ import { AuthContext } from "../context/AuthContext";
 import Router from "next/router";
 
 const CreateGroupPage = (): JSX.Element => {
-  const { user, isLoading } = useContext(AuthContext);
+  const { authUser, isLoading } = useContext(AuthContext);
   useEffect(() => {
-    if (!isLoading && user == null) {
+    if (!isLoading && authUser == null) {
       Router.push("/login");
     }
   }, [isLoading]);
   return (
     <React.Fragment>
-      {user && (
+      {authUser && (
         <Layout title="Create Group">
           <h1>Create Group</h1>
           <CreateGroupForm />

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -6,12 +6,12 @@ import { AuthContext } from "../context/AuthContext";
 import Router from "next/router";
 
 const CreateGroupPage = (): JSX.Element => {
-  const { authUser, isLoading } = useContext(AuthContext);
+  const { authUser } = useContext(AuthContext);
   useEffect(() => {
-    if (!isLoading && authUser == null) {
+    if (authUser === null) {
       Router.push("/login");
     }
-  }, [isLoading]);
+  }, [authUser]);
   return (
     <React.Fragment>
       {authUser && (

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from "react";
+import { useContext } from "react";
+import { CreateGroupForm } from "../components/CreateGroupForm";
+import Layout from "../components/Layout";
+import { AuthContext } from "../context/AuthContext";
+import Router from "next/router";
+
+const CreateGroupPage = (): JSX.Element => {
+  const { user, isLoading } = useContext(AuthContext);
+  useEffect(() => {
+    if (!isLoading && user == null) {
+      Router.push("/login");
+    }
+  }, [isLoading]);
+  return (
+    <React.Fragment>
+      {user && (
+        <Layout title="Create Group">
+          <h1>Create Group</h1>
+          <CreateGroupForm />
+        </Layout>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default CreateGroupPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ const IndexPage = (): JSX.Element => {
         const user = await loadUser(authUser.uid);
         if (user != null && !unmounted) {
           setUser(user);
+          console.log(user.groups);
           const groupIds = Object.keys(user.groups);
           const groupList: GroupWithId[] = [];
           for (const groupId of groupIds) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,23 +1,78 @@
 import Link from "next/link";
-import React from "react";
-import { useContext } from "react";
+import React, { useEffect, useContext, useState } from "react";
 import Layout from "../components/Layout";
 import { AuthContext } from "../context/AuthContext";
+import { GroupWithId, loadGroup } from "../interfaces/Group";
+import { loadUser, User } from "../interfaces/User";
 
 const IndexPage = (): JSX.Element => {
-  const authContext = useContext(AuthContext);
-  const user = authContext.user;
+  const { authUser, isLoading } = useContext(AuthContext);
+  const [user, setUser] = useState<User | null>(null);
+  const [groups, setGroups] = useState<GroupWithId[] | null>(null);
+
+  useEffect(() => {
+    // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
+    let unmounted = false;
+    const setFromDatabase = async () => {
+      if (authUser != null) {
+        // TODO エラー処理
+        const user = await loadUser(authUser.uid);
+        if (user != null && !unmounted) {
+          setUser(user);
+          const groupIds = Object.keys(user.groups);
+          const groupList: GroupWithId[] = [];
+          for (const groupId of groupIds) {
+            const group = await loadGroup(groupId);
+            if (group != null) {
+              groupList.push(group);
+            }
+          }
+          if (!unmounted) {
+            setGroups(groupList);
+          }
+        }
+      }
+    };
+    if (!isLoading) {
+      setFromDatabase();
+    }
+    const cleanup = () => {
+      unmounted = true;
+    };
+    return cleanup;
+  }, [isLoading]);
+
+  const groupListComponent = (groupList: GroupWithId[] | null): JSX.Element => {
+    if (groupList == null) {
+      return <React.Fragment />;
+    } else {
+      const component = groupList.map((g) => {
+        console.log(g.id);
+        return (
+          <div key={g.id}>
+            <p>{g.name}</p>
+          </div>
+        );
+      });
+      return (
+        <React.Fragment>
+          <p>groups:</p>
+          {component}
+        </React.Fragment>
+      );
+    }
+  };
 
   // デバッグ用にユーザー情報を表示
   return (
-    <Layout title="Home | Next.js + TypeScript Example">
-      <h1>Hello Next.js 👋</h1>
+    <Layout title="Hima Share">
+      <h1>Hello Hima Share 👋</h1>
       {user && (
         <React.Fragment>
           <p>User info</p>
-          <p>name: {user.displayName}</p>
+          <p>name: {user.name}</p>
           <p>email: {user.email}</p>
-          <p>uid: {user.uid}</p>
+          {groupListComponent(groups)}
           <p>
             <Link href="/calendar">
               <a>カレンダー</a>
@@ -30,7 +85,7 @@ const IndexPage = (): JSX.Element => {
           </p>
         </React.Fragment>
       )}
-      {!user && (
+      {!authUser && (
         <React.Fragment>
           <p className="text-main font-weight-bold">
             You are not logged in yet

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { GroupWithId, loadGroup } from "../interfaces/Group";
 import { loadUser, User } from "../interfaces/User";
 
 const IndexPage = (): JSX.Element => {
-  const { authUser, isLoading } = useContext(AuthContext);
+  const { authUser } = useContext(AuthContext);
   const [user, setUser] = useState<User | null | undefined>(undefined);
   const [groups, setGroups] = useState<GroupWithId[] | null | undefined>(
     undefined
@@ -14,6 +14,7 @@ const IndexPage = (): JSX.Element => {
 
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
+    console.log(authUser);
     let unmounted = false;
     const setFromDatabase = async () => {
       if (authUser == null) {
@@ -41,14 +42,14 @@ const IndexPage = (): JSX.Element => {
         }
       }
     };
-    if (!isLoading) {
+    if (authUser !== undefined) {
       setFromDatabase();
     }
     const cleanup = () => {
       unmounted = true;
     };
     return cleanup;
-  }, [isLoading, authUser]);
+  }, [authUser]);
 
   const groupListComponent = (
     groupList: GroupWithId[] | null | undefined
@@ -75,48 +76,44 @@ const IndexPage = (): JSX.Element => {
 
   // デバッグ用にユーザー情報を表示
   return (
-    <React.Fragment>
-      {!isLoading && (
-        <Layout title="Hima Share">
-          <h1>Hello Hima Share 👋</h1>
-          {user && (
-            <React.Fragment>
-              <p>User info</p>
-              <p>name: {user.name}</p>
-              <p>email: {user.email}</p>
-              {groupListComponent(groups)}
-              <p>
-                <Link href="/calendar">
-                  <a>カレンダー</a>
-                </Link>
-              </p>
-              <p>
-                <Link href="/create-group">
-                  <a>グループ作成</a>
-                </Link>
-              </p>
-            </React.Fragment>
-          )}
-          {user === null && (
-            <React.Fragment>
-              <p className="text-main font-weight-bold">
-                You are not logged in yet
-              </p>
-              <p>
-                <Link href="/login">
-                  <a>Login</a>
-                </Link>
-              </p>
-              <p>
-                <Link href="/register">
-                  <a>Register</a>
-                </Link>
-              </p>
-            </React.Fragment>
-          )}
-        </Layout>
+    <Layout title="Hima Share">
+      <h1>Hello Hima Share 👋</h1>
+      {user && (
+        <React.Fragment>
+          <p>User info</p>
+          <p>name: {user.name}</p>
+          <p>email: {user.email}</p>
+          {groupListComponent(groups)}
+          <p>
+            <Link href="/calendar">
+              <a>カレンダー</a>
+            </Link>
+          </p>
+          <p>
+            <Link href="/create-group">
+              <a>グループ作成</a>
+            </Link>
+          </p>
+        </React.Fragment>
       )}
-    </React.Fragment>
+      {user === null && (
+        <React.Fragment>
+          <p className="text-main font-weight-bold">
+            You are not logged in yet
+          </p>
+          <p>
+            <Link href="/login">
+              <a>Login</a>
+            </Link>
+          </p>
+          <p>
+            <Link href="/register">
+              <a>Register</a>
+            </Link>
+          </p>
+        </React.Fragment>
+      )}
+    </Layout>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,11 @@ const IndexPage = (): JSX.Element => {
               <a>カレンダー</a>
             </Link>
           </p>
+          <p>
+            <Link href="/create-group">
+              <a>グループ作成</a>
+            </Link>
+          </p>
         </React.Fragment>
       )}
       {!user && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,6 @@ const IndexPage = (): JSX.Element => {
 
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
-    console.log(authUser);
     let unmounted = false;
     const setFromDatabase = async () => {
       if (authUser == null) {
@@ -27,7 +26,6 @@ const IndexPage = (): JSX.Element => {
         const user = await loadUser(authUser.uid);
         if (user != null && !unmounted) {
           setUser(user);
-          console.log(user.groups);
           const groupIds = Object.keys(user.groups);
           const groupList: GroupWithId[] = [];
           for (const groupId of groupIds) {
@@ -58,7 +56,6 @@ const IndexPage = (): JSX.Element => {
       return <React.Fragment />;
     } else {
       const component = groupList.map((g) => {
-        console.log(g.id);
         return (
           <div key={g.id}>
             <p>{g.name}</p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,14 +7,21 @@ import { loadUser, User } from "../interfaces/User";
 
 const IndexPage = (): JSX.Element => {
   const { authUser, isLoading } = useContext(AuthContext);
-  const [user, setUser] = useState<User | null>(null);
-  const [groups, setGroups] = useState<GroupWithId[] | null>(null);
+  const [user, setUser] = useState<User | null | undefined>(undefined);
+  const [groups, setGroups] = useState<GroupWithId[] | null | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
     let unmounted = false;
     const setFromDatabase = async () => {
-      if (authUser != null) {
+      if (authUser == null) {
+        if (!unmounted) {
+          setUser(null);
+          setGroups(null);
+        }
+      } else {
         // TODO エラー処理
         const user = await loadUser(authUser.uid);
         if (user != null && !unmounted) {
@@ -41,9 +48,11 @@ const IndexPage = (): JSX.Element => {
       unmounted = true;
     };
     return cleanup;
-  }, [isLoading]);
+  }, [isLoading, authUser]);
 
-  const groupListComponent = (groupList: GroupWithId[] | null): JSX.Element => {
+  const groupListComponent = (
+    groupList: GroupWithId[] | null | undefined
+  ): JSX.Element => {
     if (groupList == null) {
       return <React.Fragment />;
     } else {
@@ -66,44 +75,48 @@ const IndexPage = (): JSX.Element => {
 
   // デバッグ用にユーザー情報を表示
   return (
-    <Layout title="Hima Share">
-      <h1>Hello Hima Share 👋</h1>
-      {user && (
-        <React.Fragment>
-          <p>User info</p>
-          <p>name: {user.name}</p>
-          <p>email: {user.email}</p>
-          {groupListComponent(groups)}
-          <p>
-            <Link href="/calendar">
-              <a>カレンダー</a>
-            </Link>
-          </p>
-          <p>
-            <Link href="/create-group">
-              <a>グループ作成</a>
-            </Link>
-          </p>
-        </React.Fragment>
+    <React.Fragment>
+      {!isLoading && (
+        <Layout title="Hima Share">
+          <h1>Hello Hima Share 👋</h1>
+          {user && (
+            <React.Fragment>
+              <p>User info</p>
+              <p>name: {user.name}</p>
+              <p>email: {user.email}</p>
+              {groupListComponent(groups)}
+              <p>
+                <Link href="/calendar">
+                  <a>カレンダー</a>
+                </Link>
+              </p>
+              <p>
+                <Link href="/create-group">
+                  <a>グループ作成</a>
+                </Link>
+              </p>
+            </React.Fragment>
+          )}
+          {user === null && (
+            <React.Fragment>
+              <p className="text-main font-weight-bold">
+                You are not logged in yet
+              </p>
+              <p>
+                <Link href="/login">
+                  <a>Login</a>
+                </Link>
+              </p>
+              <p>
+                <Link href="/register">
+                  <a>Register</a>
+                </Link>
+              </p>
+            </React.Fragment>
+          )}
+        </Layout>
       )}
-      {!authUser && (
-        <React.Fragment>
-          <p className="text-main font-weight-bold">
-            You are not logged in yet
-          </p>
-          <p>
-            <Link href="/login">
-              <a>Login</a>
-            </Link>
-          </p>
-          <p>
-            <Link href="/register">
-              <a>Register</a>
-            </Link>
-          </p>
-        </React.Fragment>
-      )}
-    </Layout>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
# 概要
- グループ作成フォームの追加
- グループのインタフェースの追加
- ユーザーのインタフェースにグループとの紐づけを追加
- AuthContextからisLoadingを削除し，代わりにauthUserがundefinedかどうかでローディング中かどうかを判別
- トップページにログインユーザーのグループ名リストを表示(デバッグ用)

# 動作確認

![hs](https://user-images.githubusercontent.com/43720583/116998413-231fb400-ad19-11eb-8877-adc1d6b4f27b.gif)

