### PR TITLE
グループカレンダー閲覧ページを作成

### DIFF
--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,11 +1,5 @@
 import Calendar from "react-calendar";
-import { DateStatus } from "../interfaces/DateStatus";
-import firebase from "firebase/app";
-
-type UserDateStatusList = {
-  user: firebase.User;
-  dateStatusList: DateStatus[];
-};
+import { UserDateStatusList } from "../interfaces/DateStatus";
 
 type GroupCalendarProps = {
   groupDateStatusList: UserDateStatusList[];

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -16,13 +16,15 @@ export const GroupCalendar = ({
   // TODO "dd日" ではなく "dd" だけ表示する
   const dateToFreeNumList: DateToNum[] = [];
   for (const userDateStatusList of groupDateStatusList) {
-    for (const dateStatus of userDateStatusList.dateStatusList) {
-      if (dateStatus.status == "calendar-free") {
+    const dateTimeList = Object.keys(userDateStatusList.dateStatusList);
+    for (const dateTime of dateTimeList) {
+      const status = userDateStatusList.dateStatusList[Number(dateTime)];
+      if (status == "calendar-free") {
         const index = dateToFreeNumList.findIndex(
-          (e) => e.date.getTime() == dateStatus.date.getTime()
+          (e) => e.date.getTime() == Number(dateTime)
         );
         if (index == -1) {
-          dateToFreeNumList.push({ date: dateStatus.date, num: 1 });
+          dateToFreeNumList.push({ date: new Date(Number(dateTime)), num: 1 });
         } else {
           dateToFreeNumList[index].num += 1;
         }

--- a/components/UserCalendar.tsx
+++ b/components/UserCalendar.tsx
@@ -1,9 +1,9 @@
 import Calendar from "react-calendar";
-import { Status, DateStatus } from "../interfaces/DateStatus";
+import { Status, DateStatusList } from "../interfaces/DateStatus";
 
 type UserCalendarProps = {
-  dateStatusList: DateStatus[];
-  setDateStatusList: (list: DateStatus[]) => void;
+  dateStatusList: DateStatusList;
+  setDateStatusList: (list: DateStatusList) => void;
 };
 
 export const UserCalendar = ({
@@ -11,19 +11,18 @@ export const UserCalendar = ({
   setDateStatusList,
 }: UserCalendarProps): JSX.Element => {
   const updateDateStatusList = async (date: Date) => {
-    const index = dateStatusList.findIndex(
-      (ds) => ds.date.getTime() == date.getTime()
-    );
+    const dateTime = date.getTime();
+    const status = dateStatusList[dateTime];
 
-    if (index == -1) {
-      const newDateStatus: DateStatus = { date: date, status: "calendar-free" };
-      setDateStatusList([...dateStatusList, newDateStatus]);
-    } else if (dateStatusList[index].status == "calendar-free") {
-      dateStatusList[index].status = "calendar-busy";
-      setDateStatusList([...dateStatusList]);
+    if (status == null) {
+      dateStatusList[dateTime] = "calendar-free";
+      setDateStatusList({ ...dateStatusList });
+    } else if (status == "calendar-free") {
+      dateStatusList[dateTime] = "calendar-busy";
+      setDateStatusList({ ...dateStatusList });
     } else {
-      dateStatusList.splice(index, 1);
-      setDateStatusList([...dateStatusList]);
+      delete dateStatusList[dateTime];
+      setDateStatusList({ ...dateStatusList });
     }
   };
 
@@ -41,13 +40,12 @@ export const UserCalendar = ({
       prev2Label={null}
       next2Label={null}
       tileClassName={({ date }): Status | null => {
-        const dateInList = dateStatusList.find(
-          (d) => d.date.getTime() == date.getTime()
-        );
-        if (dateInList == null) {
+        const dateTime = date.getTime();
+        const status = dateStatusList[dateTime];
+        if (status == null) {
           return null;
         } else {
-          return dateInList.status;
+          return status;
         }
       }}
     />

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -1,58 +1,55 @@
 import { db } from "../utils/firebase";
-import { User } from "./User";
+import { UserWithId } from "./User";
 
 export type Status = "calendar-free" | "calendar-busy";
 
-export interface DateStatus {
-  date: Date;
-  status: Status;
+// dateTime => Date: new Date(dateTime), Date => dateTime: Date.getTime()
+export interface DateStatusList {
+  [dateTime: number]: Status | undefined;
 }
 
 export interface UserDateStatusList {
-  user: User;
-  dateStatusList: DateStatus[];
+  user: UserWithId;
+  dateStatusList: DateStatusList;
 }
 
-interface formatDataType {
-  [key: number]: Status;
-}
+// interface formatDataType {
+//   [key: number]: Status;
+// }
 
-const toFormatData = (dateStatusList: DateStatus[]) => {
-  const formatData: formatDataType = {};
-  for (const dateStatus of dateStatusList) {
-    const time = dateStatus.date.getTime();
-    formatData[time] = dateStatus.status;
-  }
-  return formatData;
-};
+// const toFormatData = (dateStatusList: DateStatus[]) => {
+//   const formatData: formatDataType = {};
+//   for (const dateStatus of dateStatusList) {
+//     const time = dateStatus.date.getTime();
+//     formatData[time] = dateStatus.status;
+//   }
+//   return formatData;
+// };
 
-const fromFormatData = (formatData: formatDataType) => {
-  const dataStatusList: DateStatus[] = [];
-  for (const key in formatData) {
-    const date = new Date(Number(key));
-    const status = formatData[key];
-    dataStatusList.push({ date: date, status: status });
-  }
-  return dataStatusList;
-};
+// const fromFormatData = (formatData: formatDataType) => {
+//   const dataStatusList: DateStatus[] = [];
+//   for (const key in formatData) {
+//     const date = new Date(Number(key));
+//     const status = formatData[key];
+//     dataStatusList.push({ date: date, status: status });
+//   }
+//   return dataStatusList;
+// };
 
 export const storeDateStatusList = async (
-  dateStatusList: DateStatus[],
+  dateStatusList: DateStatusList,
   uid: string
 ): Promise<void> => {
-  const data = toFormatData(dateStatusList);
-  return db.ref(`calendars/${uid}`).set(data);
+  return db.ref(`calendars/${uid}`).set(dateStatusList);
 };
 
 export const loadDateStatusList = async (
   uid: string
-): Promise<DateStatus[] | null> => {
+): Promise<DateStatusList> => {
   const snapShot = await db.ref().child("calendars").child(uid).get();
   if (snapShot.exists()) {
-    const formatData = snapShot.val() as formatDataType;
-    const dateStatusList = fromFormatData(formatData);
-    return dateStatusList;
+    return snapShot.val() as DateStatusList;
   } else {
-    return null;
+    return [];
   }
 };

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -1,10 +1,16 @@
 import { db } from "../utils/firebase";
+import { User } from "./User";
 
 export type Status = "calendar-free" | "calendar-busy";
 
 export interface DateStatus {
   date: Date;
   status: Status;
+}
+
+export interface UserDateStatusList {
+  user: User;
+  dateStatusList: DateStatus[];
 }
 
 interface formatDataType {

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -13,29 +13,6 @@ export interface UserDateStatusList {
   dateStatusList: DateStatusList;
 }
 
-// interface formatDataType {
-//   [key: number]: Status;
-// }
-
-// const toFormatData = (dateStatusList: DateStatus[]) => {
-//   const formatData: formatDataType = {};
-//   for (const dateStatus of dateStatusList) {
-//     const time = dateStatus.date.getTime();
-//     formatData[time] = dateStatus.status;
-//   }
-//   return formatData;
-// };
-
-// const fromFormatData = (formatData: formatDataType) => {
-//   const dataStatusList: DateStatus[] = [];
-//   for (const key in formatData) {
-//     const date = new Date(Number(key));
-//     const status = formatData[key];
-//     dataStatusList.push({ date: date, status: status });
-//   }
-//   return dataStatusList;
-// };
-
 export const storeDateStatusList = async (
   dateStatusList: DateStatusList,
   uid: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "type-check": "tsc",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "yarn lint && yarn type-check && bash ./scripts/git_tag_checker.sh"
   },
   "license": "MIT",
   "devDependencies": {

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -6,7 +6,7 @@ import Layout from "../components/Layout";
 import { UserCalendar } from "../components/UserCalendar";
 import { AuthContext } from "../context/AuthContext";
 import {
-  DateStatus,
+  DateStatusList,
   loadDateStatusList,
   storeDateStatusList,
 } from "../interfaces/DateStatus";
@@ -14,7 +14,7 @@ import {
 const UserCalendarPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
   const [dateStatusList, setDateStatusList] = useState<
-    DateStatus[] | undefined
+    DateStatusList | undefined
   >(undefined);
   useEffect(() => {
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
@@ -28,7 +28,7 @@ const UserCalendarPage = (): JSX.Element => {
         if (data != null && !unmounted) {
           setDateStatusList(data);
         } else if (data == null && !unmounted) {
-          setDateStatusList([]);
+          setDateStatusList({});
         }
       }
     };

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { GetServerSideProps } from "next";
+import Layout from "../../components/Layout";
+import { ErrorPage } from "../../components/ErrorPage";
+import { GroupWithId, loadGroup } from "../../interfaces/Group";
+import { useContext, useState } from "react";
+import { AuthContext } from "../../context/AuthContext";
+import React from "react";
+import { UserDateStatusList } from "../../interfaces/DateStatus";
+import { GroupCalendar } from "../../components/GroupCalendar";
+
+type Props = {
+  initGroup?: GroupWithId;
+  errors?: string;
+};
+
+const GroupCalendarPage = ({ initGroup, errors }: Props): JSX.Element => {
+  if (errors) {
+    return <ErrorPage errorMessage={errors} />;
+  }
+  if (!initGroup) {
+    return <ErrorPage />;
+  }
+  const { authUser } = useContext(AuthContext);
+  if (authUser === undefined) {
+    return <React.Fragment />;
+  }
+  if (
+    authUser === null ||
+    initGroup.members == null ||
+    !Object.keys(initGroup.members).includes(authUser.uid)
+  ) {
+    return <ErrorPage errorMessage={"Invalid URL"} />;
+  }
+
+  const userIds = Object.keys(initGroup.members);
+  const [groupDateStatusList, setGroupDateStatusList] = useState<
+    UserDateStatusList[]
+  >([]);
+
+  return (
+    <Layout title="招待を作成">
+      <GroupCalendar groupDateStatusList={groupDateStatusList} />
+      <Link href="/">
+        <a>戻る</a>
+      </Link>
+    </Layout>
+  );
+};
+
+export default GroupCalendarPage;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { groupId } = context.query;
+  if (groupId == null || Array.isArray(groupId)) {
+    return { props: { errors: "Invalid URL" } };
+  } else {
+    const initGroup = await loadGroup(groupId);
+    if (initGroup == null) {
+      return { props: { errors: "Invalid URL" } };
+    } else {
+      return { props: { initGroup } };
+    }
+  }
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,25 +57,37 @@ const IndexPage = (): JSX.Element => {
       if (g.invitationId == null) {
         return (
           <div key={g.id}>
-            <p>{g.name}</p>
-            <Link
-              href="/create-invitation/[id]"
-              as={`/create-invitation/${g.id}`}
-            >
-              <a>招待リンク作成</a>
-            </Link>
+            <div>
+              <Link href="/groups/[id]" as={`/groups/${g.id}`}>
+                <a>{g.name}</a>
+              </Link>
+            </div>
+            <div>
+              <Link
+                href="/create-invitation/[id]"
+                as={`/create-invitation/${g.id}`}
+              >
+                <a>招待リンク作成</a>
+              </Link>
+            </div>
           </div>
         );
       } else {
         return (
           <div key={g.id}>
-            <p>{g.name}</p>
-            <Link
-              href="/invitations/[id]"
-              as={`/invitations/${g.invitationId}`}
-            >
-              <a>招待リンク確認</a>
-            </Link>
+            <div>
+              <Link href="/groups/[id]" as={`/groups/${g.id}`}>
+                <a>{g.name}</a>
+              </Link>
+            </div>
+            <div>
+              <Link
+                href="/invitations/[id]"
+                as={`/invitations/${g.invitationId}`}
+              >
+                <a>招待リンク確認</a>
+              </Link>
+            </div>
           </div>
         );
       }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,19 +1,31 @@
 import Link from "next/link";
 import Router from "next/router";
+import React, { useEffect, useContext } from "react";
 import Layout from "../components/Layout";
 import { LoginForm } from "../components/LoginForm";
+import { AuthContext } from "../context/AuthContext";
 
 const LoginPage = (): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  useEffect(() => {
+    if (authUser !== null) {
+      Router.push("/");
+    }
+  }, [authUser]);
   return (
-    <Layout title="Login">
-      <h1>Login</h1>
-      <LoginForm onLogined={() => Router.push("/")} />
-      <p>
-        <Link href="/register">
-          <a>登録</a>
-        </Link>
-      </p>
-    </Layout>
+    <React.Fragment>
+      {authUser === null && (
+        <Layout title="Login">
+          <h1>Login</h1>
+          <LoginForm onLogined={() => Router.push("/")} />
+          <p>
+            <Link href="/register">
+              <a>登録</a>
+            </Link>
+          </p>
+        </Layout>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,19 +1,31 @@
 import Link from "next/link";
 import Router from "next/router";
+import React, { useEffect, useContext } from "react";
 import Layout from "../components/Layout";
 import { RegisterForm } from "../components/RegisterForm";
+import { AuthContext } from "../context/AuthContext";
 
 const RegisterPage = (): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  useEffect(() => {
+    if (authUser !== null) {
+      Router.push("/");
+    }
+  }, [authUser]);
   return (
-    <Layout title="Register">
-      <h1>Register</h1>
-      <RegisterForm onRegistered={() => Router.push("/calendar")} />
-      <p>
-        <Link href="/login">
-          <a>ログイン</a>
-        </Link>
-      </p>
-    </Layout>
+    <React.Fragment>
+      {authUser === null && (
+        <Layout title="Register">
+          <h1>Register</h1>
+          <RegisterForm onRegistered={() => Router.push("/calendar")} />
+          <p>
+            <Link href="/login">
+              <a>ログイン</a>
+            </Link>
+          </p>
+        </Layout>
+      )}
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
# 概要

- 参加ユーザーの予定を集計するグループカレンダーページを作成
- Date型をInterfaceに用いるとJsonとしてシリアライズできずgetServerSidePropsでエラーが起きるのでgetTimeでnumber型に変換してやり取りするようにした
- コンポーネントとしての機能は #23 を参照

# 動作確認

![hs](https://user-images.githubusercontent.com/43720583/117294594-c7d2fa80-aead-11eb-9c93-ecd140fd4a8f.gif)
