### PR TITLE
グループカレンダーの日付をクリックすると暇なユーザー一覧を表示

### DIFF
--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -71,6 +71,7 @@ export const GroupCalendar = ({
   };
 
   // TODO 別ファイルに分ける
+  // TODO きれいに表示する
   const tooltipComponent = (date: Date): JSX.Element => {
     const dateTime = date.getTime();
     const statusInfo = dateToStatusInfoList[dateTime];

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,49 +1,114 @@
+import { UserWithId } from "interfaces/User";
 import React, { useRef, useState } from "react";
 import { Overlay, Tooltip } from "react-bootstrap";
 import Calendar from "react-calendar";
-import { UserDateStatusList } from "../interfaces/DateStatus";
+import { Status, UserDateStatusList } from "../interfaces/DateStatus";
 
-type GroupCalendarProps = {
+interface GroupCalendarProps {
   groupDateStatusList: UserDateStatusList[];
-};
+}
 
-type DateToNum = {
-  date: Date;
-  num: number;
-};
+interface UsersStatus {
+  [uid: string]: Status | undefined;
+}
+
+interface StatusInfo {
+  free: number;
+  busy: number;
+  usersStatus: UsersStatus;
+}
+interface DateTimeToStatusInfoList {
+  [dateTime: number]: StatusInfo | undefined;
+}
 
 export const GroupCalendar = ({
   groupDateStatusList: groupDateStatusList,
 }: GroupCalendarProps): JSX.Element => {
+  const users = groupDateStatusList.map(
+    (groupDateStatus) => groupDateStatus.user
+  );
   const calendarRef = useRef(null);
   const [showTooltip, setShowTooltip] = useState(false);
   const [focusedDate, setFocusedDate] = useState<Date | undefined>(undefined);
   // TODO "dd日" ではなく "dd" だけ表示する
-  const dateToFreeNumList: DateToNum[] = [];
+  const dateToStatusInfoList: DateTimeToStatusInfoList = {};
+
   for (const userDateStatusList of groupDateStatusList) {
+    const user = userDateStatusList.user;
     const dateTimeList = Object.keys(userDateStatusList.dateStatusList);
     for (const dateTime of dateTimeList) {
-      const status = userDateStatusList.dateStatusList[Number(dateTime)];
-      if (status == "calendar-free") {
-        const index = dateToFreeNumList.findIndex(
-          (e) => e.date.getTime() == Number(dateTime)
-        );
-        if (index == -1) {
-          dateToFreeNumList.push({ date: new Date(Number(dateTime)), num: 1 });
-        } else {
-          dateToFreeNumList[index].num += 1;
+      const numberDateTime = Number(dateTime);
+      if (dateToStatusInfoList[numberDateTime] == null) {
+        dateToStatusInfoList[numberDateTime] = {
+          free: 0,
+          busy: 0,
+          usersStatus: {},
+        };
+      }
+      const status = userDateStatusList.dateStatusList[numberDateTime];
+      const statusInfo = dateToStatusInfoList[numberDateTime];
+      if (statusInfo != null) {
+        if (status == "calendar-free") {
+          statusInfo.free += 1;
+        } else if (status == "calendar-busy") {
+          statusInfo.busy += 1;
+        }
+        if (status != null) {
+          statusInfo.usersStatus[user.id] = status;
         }
       }
     }
   }
+
   const countFreeNum = (date: Date): number => {
-    const dateToFreeNum = dateToFreeNumList.find(
-      (e) => e.date.getTime() == date.getTime()
-    );
-    if (dateToFreeNum == null) {
+    const dateTime = date.getTime();
+    const statusInfo = dateToStatusInfoList[dateTime];
+    if (statusInfo == null) {
       return 0;
     } else {
-      return dateToFreeNum.num;
+      return statusInfo.free;
+    }
+  };
+
+  // TODO 別ファイルに分ける
+  const tooltipComponent = (date: Date): JSX.Element => {
+    const dateTime = date.getTime();
+    const statusInfo = dateToStatusInfoList[dateTime];
+    const userStatusComponents = users.map((user) => {
+      if (statusInfo == null) {
+        return <div key={user.id}>{user.name}: 未入力</div>;
+      } else {
+        const status = statusInfo.usersStatus[user.id];
+        if (status == null) {
+          return <div key={user.id}>{user.name}: 未入力</div>;
+        } else {
+          const statusText = status == "calendar-free" ? "〇" : "×";
+          return (
+            <div key={user.id}>
+              {user.name}: {statusText}
+            </div>
+          );
+        }
+      }
+    });
+    if (statusInfo == null) {
+      return (
+        <React.Fragment>
+          <p>{date.toString()}</p>
+          <p>暇な人: {0}</p>
+          <p>忙しい人: {0}</p>
+          {userStatusComponents}
+        </React.Fragment>
+      );
+    } else {
+      return (
+        <React.Fragment>
+          <p>{date.toString()}</p>
+          <p>暇な人: {statusInfo.free}</p>
+          <p>忙しい人: {statusInfo.busy}</p>
+          {userStatusComponents}
+        </React.Fragment>
+      );
     }
   };
   return (
@@ -93,7 +158,7 @@ export const GroupCalendar = ({
             id="overlay-example"
             {...props}
           >
-            {focusedDate?.toString()}
+            {focusedDate && tooltipComponent(focusedDate)}
           </Tooltip>
         )}
       </Overlay>

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,4 +1,3 @@
-import { UserWithId } from "interfaces/User";
 import React, { useRef, useState } from "react";
 import { Overlay, Tooltip } from "react-bootstrap";
 import Calendar from "react-calendar";

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,3 +1,5 @@
+import React, { useRef, useState } from "react";
+import { Overlay, Tooltip } from "react-bootstrap";
 import Calendar from "react-calendar";
 import { UserDateStatusList } from "../interfaces/DateStatus";
 
@@ -13,6 +15,9 @@ type DateToNum = {
 export const GroupCalendar = ({
   groupDateStatusList: groupDateStatusList,
 }: GroupCalendarProps): JSX.Element => {
+  const calendarRef = useRef(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [focusedDate, setFocusedDate] = useState<Date | undefined>(undefined);
   // TODO "dd日" ではなく "dd" だけ表示する
   const dateToFreeNumList: DateToNum[] = [];
   for (const userDateStatusList of groupDateStatusList) {
@@ -42,31 +47,56 @@ export const GroupCalendar = ({
     }
   };
   return (
-    <Calendar
-      locale="ja-JP"
-      minDate={new Date()}
-      minDetail="month"
-      maxDetail="month"
-      defaultView="month"
-      showNavigation={true}
-      prev2Label={null}
-      next2Label={null}
-      tileContent={({ date }) => {
-        const freeNum = countFreeNum(date);
-        return <div>{freeNum}</div>;
-      }}
-      tileClassName={({ date }) => {
-        const freeNum = countFreeNum(date);
-        // TODO 暇な人の人数でスタイルを変えるための基準人数を設定可能にする
-        // TODO 色はグラデーションでもいいかもしれない
-        if (freeNum >= 5) {
-          return "calendar-free";
-        } else if (freeNum >= 2) {
-          return "calendar-light-free";
-        } else {
-          return null;
-        }
-      }}
-    />
+    <React.Fragment>
+      <div></div>
+      <Calendar
+        inputRef={calendarRef}
+        onClickDay={(date) => {
+          setFocusedDate(date);
+          setShowTooltip(true);
+        }}
+        locale="ja-JP"
+        minDate={new Date()}
+        minDetail="month"
+        maxDetail="month"
+        defaultView="month"
+        showNavigation={true}
+        prev2Label={null}
+        next2Label={null}
+        tileContent={({ date }) => {
+          const freeNum = countFreeNum(date);
+          return <div>{freeNum}</div>;
+        }}
+        tileClassName={({ date }) => {
+          const freeNum = countFreeNum(date);
+          // TODO 暇な人の人数でスタイルを変えるための基準人数を設定可能にする
+          // TODO 色はグラデーションでもいいかもしれない
+          if (freeNum >= 5) {
+            return "calendar-free";
+          } else if (freeNum >= 2) {
+            return "calendar-light-free";
+          } else {
+            return null;
+          }
+        }}
+      />
+      <Overlay
+        target={calendarRef.current}
+        show={showTooltip}
+        placement="right"
+      >
+        {(props) => (
+          <Tooltip
+            onClick={() => {
+              setShowTooltip(false);
+            }}
+            id="overlay-example"
+            {...props}
+          >
+            {focusedDate?.toString()}
+          </Tooltip>
+        )}
+      </Overlay>
+    </React.Fragment>
   );
 };

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -23,7 +23,7 @@ export const storeDateStatusList = async (
 export const loadDateStatusList = async (
   uid: string
 ): Promise<DateStatusList> => {
-  const snapShot = await db.ref().child("calendars").child(uid).get();
+  const snapShot = await db.ref().child("calendars").child(uid).once("value");
   if (snapShot.exists()) {
     return snapShot.val() as DateStatusList;
   } else {

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -1,5 +1,6 @@
 import { db } from "../utils/firebase";
 import { UserWithId } from "./User";
+import firebase from "firebase/app";
 
 export type Status = "calendar-free" | "calendar-busy";
 
@@ -29,4 +30,32 @@ export const loadDateStatusList = async (
   } else {
     return [];
   }
+};
+
+export const watchDateStatusList = (
+  uid: string,
+  eventType: firebase.database.EventType,
+  onValueChanged: (
+    key: string | null,
+    value?: DateStatusList | null,
+    childValue?: Status | null
+  ) => void
+): void => {
+  const ref = db.ref(`calendars/${uid}`);
+  ref.on(eventType, (snapShot) => {
+    if (eventType == "value") {
+      const key = snapShot.key;
+      const data = snapShot.val() as DateStatusList | null;
+      onValueChanged(key, data, undefined);
+    } else {
+      const key = snapShot.key;
+      const childData = snapShot.val() as Status | null;
+      onValueChanged(key, undefined, childData);
+    }
+  });
+};
+
+export const unWatchDataStatusList = (uid: string): void => {
+  const ref = db.ref(`calendars/${uid}`);
+  ref.off();
 };

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -1,5 +1,6 @@
 import { db } from "../utils/firebase";
 import { joinGroup } from "./User";
+import firebase from "firebase/app";
 
 export interface Group {
   name: string;
@@ -8,6 +9,12 @@ export interface Group {
   };
   invitationId?: string;
 }
+
+type GroupChild =
+  | string
+  | {
+      [uid: string]: true;
+    };
 
 export interface GroupWithId extends Group {
   id: string;
@@ -41,4 +48,32 @@ export const setInvitation = async (
 ): Promise<string> => {
   await db.ref(`groups/${groupId}`).update({ invitationId: invitationId });
   return invitationId;
+};
+
+export const watchGroup = (
+  groupId: string,
+  eventType: firebase.database.EventType,
+  onValueChanged: (
+    key: string | null,
+    value?: Group | null,
+    childValue?: GroupChild | null
+  ) => void
+): void => {
+  const ref = db.ref(`groups/${groupId}`);
+  ref.on(eventType, (snapShot) => {
+    if (eventType == "value") {
+      const key = snapShot.key;
+      const data = snapShot.val() as Group | null;
+      onValueChanged(key, data, undefined);
+    } else {
+      const key = snapShot.key;
+      const childData = snapShot.val() as GroupChild | null;
+      onValueChanged(key, undefined, childData);
+    }
+  });
+};
+
+export const unWatchGroup = (groupId: string): void => {
+  const ref = db.ref(`groups/${groupId}`);
+  ref.off();
 };

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -26,7 +26,7 @@ export const storeGroup = async (group: Group, uid: string): Promise<void> => {
 export const loadGroup = async (
   groupId: string
 ): Promise<GroupWithId | null> => {
-  const snapShot = await db.ref().child("groups").child(groupId).get();
+  const snapShot = await db.ref().child("groups").child(groupId).once("value");
   if (snapShot.exists()) {
     const group = snapShot.val() as Group;
     return { ...group, id: groupId };

--- a/interfaces/Invitation.ts
+++ b/interfaces/Invitation.ts
@@ -31,7 +31,7 @@ export const loadInvitation = async (
     .ref()
     .child("invitations")
     .child(invitationId)
-    .get();
+    .once("value");
   if (snapShot.exists()) {
     const invitation = snapShot.val() as Invitation;
     return { ...invitation, id: invitationId };

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -17,7 +17,7 @@ export const storeUser = (user: User, uid: string): Promise<void> => {
 };
 
 export const loadUser = async (uid: string): Promise<UserWithId | null> => {
-  const snapShot = await db.ref().child("users").child(uid).get();
+  const snapShot = await db.ref().child("users").child(uid).once("value");
   if (snapShot.exists()) {
     const user = snapShot.val() as User;
     return { ...user, id: uid };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -25,29 +25,31 @@ const GroupCalendarPage = ({
   initGroupDateStatusList,
   errors,
 }: Props): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  const [group, setGroup] = useState(initGroup);
+  const [groupDateStatusList, setGroupDateStatusList] = useState(
+    initGroupDateStatusList
+  );
+
   if (errors) {
     return <ErrorPage errorMessage={errors} />;
   }
-  if (!initGroup || !initGroupDateStatusList) {
+  if (!group || !groupDateStatusList) {
     return <ErrorPage />;
   }
-  const { authUser } = useContext(AuthContext);
   if (authUser === undefined) {
     return <React.Fragment />;
   }
   if (
     authUser === null ||
-    initGroup.members == null ||
-    !Object.keys(initGroup.members).includes(authUser.uid)
+    group.members == null ||
+    !Object.keys(group.members).includes(authUser.uid)
   ) {
     return <ErrorPage errorMessage={"Invalid URL"} />;
   }
 
   // TODO Firebaseのon()メソッドを用いてリアルタイムでカレンダーが変わるようにする
-  const [group, setGroup] = useState(initGroup);
-  const [groupDateStatusList, setGroupDateStatusList] = useState(
-    initGroupDateStatusList
-  );
+
   const reload = async () => {
     const newGroup = await loadGroup(group.id);
     if (newGroup != null && newGroup.members != null) {
@@ -71,7 +73,7 @@ const GroupCalendarPage = ({
 
   return (
     <React.Fragment>
-      {groupDateStatusList && (
+      {groupDateStatusList && group && (
         <Layout title={group.name}>
           <Button variant="accent" type="button" onClick={reload}>
             更新

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -56,16 +56,18 @@ const GroupCalendarPage = ({
       const userIds = Object.keys(newGroup.members);
       const newGroupDateStatusList = [];
 
-      const users = await Promise.all(
-        userIds.map((userId) => loadUser(userId))
-      );
       const usersDateStatusList = await Promise.all(
-        userIds.map((userId) => loadDateStatusList(userId))
+        userIds.map(async (userId) => {
+          return {
+            user: await loadUser(userId),
+            dateStatusList: await loadDateStatusList(userId),
+          };
+        })
       );
 
       for (let i = 0; i < userIds.length; i++) {
-        const user = users[i];
-        const userDateStatusList = usersDateStatusList[i];
+        const user = usersDateStatusList[i].user;
+        const userDateStatusList = usersDateStatusList[i].dateStatusList;
         if (user == null) {
           return { props: { errors: "Unexpected Error" } };
         }
@@ -121,15 +123,18 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     } else {
       const userIds = Object.keys(initGroup.members);
       const initGroupDateStatusList: UserDateStatusList[] = [];
-      const users = await Promise.all(
-        userIds.map((userId) => loadUser(userId))
-      );
+
       const usersDateStatusList = await Promise.all(
-        userIds.map((userId) => loadDateStatusList(userId))
+        userIds.map(async (userId) => {
+          return {
+            user: await loadUser(userId),
+            dateStatusList: await loadDateStatusList(userId),
+          };
+        })
       );
       for (let i = 0; i < userIds.length; i++) {
-        const user = users[i];
-        const userDateStatusList = usersDateStatusList[i];
+        const user = usersDateStatusList[i].user;
+        const userDateStatusList = usersDateStatusList[i].dateStatusList;
         if (user == null) {
           return { props: { errors: "Unexpected Error" } };
         }

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -55,9 +55,17 @@ const GroupCalendarPage = ({
     if (newGroup != null && newGroup.members != null) {
       const userIds = Object.keys(newGroup.members);
       const newGroupDateStatusList = [];
-      for (const userId of userIds) {
-        const user = await loadUser(userId);
-        const userDateStatusList = await loadDateStatusList(userId);
+
+      const users = await Promise.all(
+        userIds.map((userId) => loadUser(userId))
+      );
+      const usersDateStatusList = await Promise.all(
+        userIds.map((userId) => loadDateStatusList(userId))
+      );
+
+      for (let i = 0; i < userIds.length; i++) {
+        const user = users[i];
+        const userDateStatusList = usersDateStatusList[i];
         if (user == null) {
           return { props: { errors: "Unexpected Error" } };
         }
@@ -66,6 +74,18 @@ const GroupCalendarPage = ({
           dateStatusList: userDateStatusList,
         });
       }
+      newGroupDateStatusList.sort((a, b) => {
+        const nameA = a.user.name.toUpperCase();
+        const nameB = b.user.name.toUpperCase();
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
+        return 0;
+      });
+
       setGroup(newGroup);
       setGroupDateStatusList(newGroupDateStatusList);
     }
@@ -101,9 +121,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     } else {
       const userIds = Object.keys(initGroup.members);
       const initGroupDateStatusList: UserDateStatusList[] = [];
-      for (const userId of userIds) {
-        const user = await loadUser(userId);
-        const userDateStatusList = await loadDateStatusList(userId);
+      const users = await Promise.all(
+        userIds.map((userId) => loadUser(userId))
+      );
+      const usersDateStatusList = await Promise.all(
+        userIds.map((userId) => loadDateStatusList(userId))
+      );
+      for (let i = 0; i < userIds.length; i++) {
+        const user = users[i];
+        const userDateStatusList = usersDateStatusList[i];
         if (user == null) {
           return { props: { errors: "Unexpected Error" } };
         }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,14 +30,27 @@ const IndexPage = (): JSX.Element => {
           const groupList: GroupWithId[] = [];
           if (user.groups != null) {
             const groupIds = Object.keys(user.groups);
-            for (const groupId of groupIds) {
-              const group = await loadGroup(groupId);
+            const groupsfromDatabase = await Promise.all(
+              groupIds.map((groupId) => loadGroup(groupId))
+            );
+            for (const group of groupsfromDatabase) {
               if (group != null) {
                 groupList.push(group);
               }
             }
           }
           if (!unmounted) {
+            groupList.sort((a, b) => {
+              const nameA = a.name.toUpperCase();
+              const nameB = b.name.toUpperCase();
+              if (nameA < nameB) {
+                return -1;
+              }
+              if (nameA > nameB) {
+                return 1;
+              }
+              return 0;
+            });
             setGroups(groupList);
           }
         }

--- a/pages/invitations/[invitationId].tsx
+++ b/pages/invitations/[invitationId].tsx
@@ -7,10 +7,11 @@ import {
   InvitationWithId,
   loadInvitation,
 } from "../../interfaces/Invitation";
-import React, { useContext } from "react";
+import React, { useContext, useRef, useState } from "react";
 import Router from "next/router";
 import { AuthContext } from "../../context/AuthContext";
 import { GroupWithId, loadGroup } from "../../interfaces/Group";
+import { Overlay, Tooltip } from "react-bootstrap";
 
 type Props = {
   invitation?: InvitationWithId;
@@ -25,6 +26,9 @@ const CreateInvitationPage = ({
   appUrl,
   errors,
 }: Props): JSX.Element => {
+  const [showTooltip, setShowTooltop] = useState(false);
+  const invitationUrlInput = useRef(null);
+
   if (errors) {
     return <ErrorPage errorMessage={errors} />;
   }
@@ -52,6 +56,7 @@ const CreateInvitationPage = ({
     if (joinUrlElement != null) {
       joinUrlElement.select();
       document.execCommand("copy");
+      setShowTooltop(true);
     }
   };
   const invalidateInvitation = async (
@@ -67,13 +72,28 @@ const CreateInvitationPage = ({
     <Layout title="招待URL">
       <p>招待URLは以下です(クリックでコピー)</p>
       <input
+        ref={invitationUrlInput}
         type="text"
         id="hima-share-join-url"
         className="form-control"
         onClick={copyURL}
+        onBlur={() => {
+          setShowTooltop(false);
+        }}
         value={joinUrl}
         readOnly
       />
+      <Overlay
+        target={invitationUrlInput.current}
+        show={showTooltip}
+        placement="top"
+      >
+        {(props) => (
+          <Tooltip id="copy-url-tooltip" {...props}>
+            コピーしました！
+          </Tooltip>
+        )}
+      </Overlay>
       <p>友達にシェアしよう!</p>
       <div>
         <a href="" onClick={invalidateInvitation}>

--- a/styles/sass/calendar.scss
+++ b/styles/sass/calendar.scss
@@ -30,10 +30,15 @@
   background-color: #ffffa9 !important;
 }
 
-// Set Saturday's text color to blue
+// Set Saturday's text color to blue expect disable day
+// Set Sunday's text color to red expect disable day
 
 .react-calendar__tile:nth-child(7n-1) {
   color: #0000ff;
+}
+
+.react-calendar__tile:nth-child(7n) {
+  color: #ff0000;
 }
 
 .react-calendar__month-view__days__day--neighboringMonth {

--- a/styles/sass/calendar.scss
+++ b/styles/sass/calendar.scss
@@ -19,6 +19,17 @@
   background-color: #e6e6e6 !important;
 }
 
+// Set today background color and border
+
+.react-calendar__tile--now {
+  background-color: #ffff76 !important;
+  border: 3px solid #ffff76 !important;
+}
+
+.react-calendar__tile--now:hover {
+  background-color: #ffffa9 !important;
+}
+
 // Set Saturday's text color to blue
 
 .react-calendar__tile:nth-child(7n-1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,12 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "baseUrl": "./",
+    "paths": {
+      "react-calendar": ["./types/react-calendar"]
+    },
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "exclude": ["node_modules", "_app.tsx"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -1,0 +1,9 @@
+// TODO @types/react-calendar が更新されていないので対症療法. @types/react-calendarが更新されたら更新する
+// inputRefについてのIssue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52547
+import { CalendarProps } from "../../node_modules/@types/react-calendar/";
+
+export default function Calendar(props: MyCalendarProps): JSX.Element;
+
+export interface MyCalendarProps extends CalendarProps {
+  inputRef?: React.RefObject<JSX.Element>;
+}


### PR DESCRIPTION
# 概要

- Tooltipを用いてグループカレンダーの日付をクリックするとその日の日付，暇な人の人数，忙しい人の人数，それぞれのユーザーの入力(暇or忙しいor未入力)を表示するようにした
  - @types/react-calendaの型定義がreact-calendar本家に追いついておらず必要なPropsの型がなかったので新しくindex.d.tsを作成して型定義を拡張した
  - **表示デザインは適当なので要修正**
  - **日付クリックからの招待メッセージ作成は未実装**
- カレンダーの日付クリック時に日曜日のテキストカラーが黒色になっていたのを修正
- forループ+awaitで書いてた部分ををPromise.allで書き換え
- 招待リンク確認ページで招待リンククリック時にコピーしましたというTooltipを表示


# 動作確認

![a201844892900f7de63dcd77520116d1](https://user-images.githubusercontent.com/43720583/117476604-02b15d00-af98-11eb-8ce0-756d4cf2cb25.png)