### PR TITLE
カレンダーの日付表示を"dd日"ではなく"dd"とだけ表示する

### DIFF
--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -125,6 +125,10 @@ export const GroupCalendar = ({
         minDetail="month"
         maxDetail="month"
         defaultView="month"
+        formatDay={(_locale, date) => {
+          const day = date.getDate();
+          return `${day}`;
+        }}
         showNavigation={true}
         prev2Label={null}
         next2Label={null}

--- a/components/UserCalendar.tsx
+++ b/components/UserCalendar.tsx
@@ -36,6 +36,10 @@ export const UserCalendar = ({
       minDetail="month"
       maxDetail="month"
       defaultView="month"
+      formatDay={(_locale, date) => {
+        const day = date.getDate();
+        return `${day}`;
+      }}
       showNavigation={true}
       prev2Label={null}
       next2Label={null}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -1,9 +1,14 @@
-// TODO @types/react-calendar が更新されていないので対症療法. @types/react-calendarが更新されたら更新する
+// TODO @types/react-calendar が更新されていないので対症療法. @types/react-calendarが更新されたら不要になる
 // inputRefについてのIssue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52547
-import { CalendarProps } from "../../node_modules/@types/react-calendar/";
+// formatDayについてのPR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52556
+import {
+  CalendarProps,
+  FormatterCallback,
+} from "../../node_modules/@types/react-calendar/";
 
 export default function Calendar(props: MyCalendarProps): JSX.Element;
 
 export interface MyCalendarProps extends CalendarProps {
   inputRef?: React.RefObject<JSX.Element>;
+  formatDay?: FormatterCallback;
 }


### PR DESCRIPTION
# 概要

- @types/react-calendarを拡張してformatDayの型を追加し，カレンダーの日付表示を"dd"のみに変更した

# 動作確認

![efa4a1c4bc3ce3c0899714532f568ec2](https://user-images.githubusercontent.com/43720583/117479014-cb907b00-af9a-11eb-9208-a4e345050e01.png)

