### PR TITLE
グループカレンダーからその日付で誘うチャットメッセージを作成する

### DIFF
--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -7,10 +7,10 @@ import React, { useContext } from "react";
 import { AuthContext } from "../context/AuthContext";
 import { Group, storeGroup } from "../interfaces/Group";
 
-type InputsType = {
+interface InputsType {
   name: string;
   chatId: string;
-};
+}
 
 const schema = yup.object().shape({
   name: yup.string().required("名前は必須です"),

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -9,10 +9,12 @@ import { Group, storeGroup } from "../interfaces/Group";
 
 type InputsType = {
   name: string;
+  chatId: string;
 };
 
 const schema = yup.object().shape({
   name: yup.string().required("名前は必須です"),
+  chatId: yup.string(),
 });
 
 export const CreateGroupForm = (): JSX.Element => {
@@ -34,7 +36,7 @@ export const CreateGroupForm = (): JSX.Element => {
       const group: Group = {
         name: data["name"],
       };
-      storeGroup(group, authUser.uid)
+      storeGroup(group, authUser.uid, data["chatId"])
         .then(() => {
           Router.push("/");
         })
@@ -49,14 +51,20 @@ export const CreateGroupForm = (): JSX.Element => {
     <Form onSubmit={handleSubmit(createGroup)}>
       <Form.Group>
         <Form.Label>Group Name</Form.Label>
-        <Form.Control
-          type="name"
-          isInvalid={!!errors.name}
-          {...register("name")}
-        />
+        <Form.Control isInvalid={!!errors.name} {...register("name")} />
         {errors.name && (
           <Form.Control.Feedback type="invalid">
             {errors.name.message}
+          </Form.Control.Feedback>
+        )}
+      </Form.Group>
+
+      <Form.Group>
+        <Form.Label>Chat ID</Form.Label>
+        <Form.Control isInvalid={!!errors.chatId} {...register("chatId")} />
+        {errors.chatId && (
+          <Form.Control.Feedback type="invalid">
+            {errors.chatId.message}
           </Form.Control.Feedback>
         )}
       </Form.Group>

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -9,11 +9,13 @@ import { Group, storeGroup } from "../interfaces/Group";
 
 interface InputsType {
   name: string;
+  description: string;
   chatId: string;
 }
 
 const schema = yup.object().shape({
   name: yup.string().required("名前は必須です"),
+  description: yup.string(),
   chatId: yup.string(),
 });
 
@@ -35,6 +37,7 @@ export const CreateGroupForm = (): JSX.Element => {
     if (authUser != null) {
       const group: Group = {
         name: data["name"],
+        description: data["description"],
       };
       storeGroup(group, authUser.uid, data["chatId"])
         .then(() => {
@@ -55,6 +58,19 @@ export const CreateGroupForm = (): JSX.Element => {
         {errors.name && (
           <Form.Control.Feedback type="invalid">
             {errors.name.message}
+          </Form.Control.Feedback>
+        )}
+      </Form.Group>
+
+      <Form.Group>
+        <Form.Label>グループの概要</Form.Label>
+        <Form.Control
+          isInvalid={!!errors.description}
+          {...register("description")}
+        />
+        {errors.description && (
+          <Form.Control.Feedback type="invalid">
+            {errors.description.message}
           </Form.Control.Feedback>
         )}
       </Form.Group>

--- a/components/EventMessage.tsx
+++ b/components/EventMessage.tsx
@@ -1,0 +1,18 @@
+import { UserWithId } from "interfaces/User";
+import React from "react";
+import { Button } from "react-bootstrap";
+
+interface EventMessageProps {
+  users: UserWithId[];
+}
+
+export const EventMessage = ({ users }: EventMessageProps) => {
+  return (
+    <React.Fragment>
+      <p>募集メッセージ</p>
+      <Button variant="accent" size="sm">
+        コピー
+      </Button>
+    </React.Fragment>
+  );
+};

--- a/components/EventMessage.tsx
+++ b/components/EventMessage.tsx
@@ -1,18 +1,81 @@
-import { UserWithId } from "interfaces/User";
-import React from "react";
-import { Button } from "react-bootstrap";
+import React, { useState, useRef } from "react";
+import { Button, Form, Overlay, Tooltip } from "react-bootstrap";
 
 interface EventMessageProps {
-  users: UserWithId[];
+  dateText: string;
+  freeChatIds: string[];
+  unEnteredChatIds: string[];
 }
 
-export const EventMessage = ({ users }: EventMessageProps) => {
+export const EventMessage = ({
+  dateText,
+  freeChatIds,
+  unEnteredChatIds,
+}: EventMessageProps): JSX.Element => {
+  const eventMessageInputRef = useRef(null);
+  // TODO グループ設定で変更可能にする
+  const eventMessage = `${dateText}に一緒に〇〇しませんか？`;
+  const initFullMessage = `${freeChatIds.join(" ")} ${eventMessage}`;
+
+  const [fullMessage, setFullMessage] = useState(initFullMessage);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const copyMessage = () => {
+    const eventMessageElement = document.getElementById(
+      "hima-share-event-message"
+    ) as HTMLInputElement;
+    if (eventMessageElement != null) {
+      eventMessageElement.select();
+      document.execCommand("copy");
+      setShowTooltip(true);
+    }
+  };
+  const onChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+    if (checked) {
+      setFullMessage(
+        `${freeChatIds.join(" ")} ${unEnteredChatIds.join(" ")} ${eventMessage}`
+      );
+    } else {
+      setFullMessage(`${freeChatIds.join(" ")} ${eventMessage}`);
+    }
+  };
+
   return (
     <React.Fragment>
       <p>募集メッセージ</p>
-      <Button variant="accent" size="sm">
+      <Form.Check
+        type="checkbox"
+        label="未入力の人を含める"
+        onChange={onChecked}
+      />
+      <Button variant="accent" size="sm" onClick={copyMessage}>
         コピー
       </Button>
+      <input
+        id="hima-share-event-message"
+        ref={eventMessageInputRef}
+        type="text"
+        className="form-control"
+        value={fullMessage}
+        onChange={(event) => {
+          setFullMessage(event.target.value);
+        }}
+        onBlur={() => {
+          setShowTooltip(false);
+        }}
+      />
+      <Overlay
+        target={eventMessageInputRef.current}
+        show={showTooltip}
+        placement="top"
+      >
+        {(props) => (
+          <Tooltip id="event-message-tooltip" {...props}>
+            コピーしました！
+          </Tooltip>
+        )}
+      </Overlay>
     </React.Fragment>
   );
 };

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -60,20 +60,15 @@ export const GroupCalendar = ({
 
   return (
     <React.Fragment>
-      <div
-        onClick={() => {
+      <UserInfoOfDay
+        date={focusedDate}
+        users={users}
+        dateToStatusInfoList={dateToStatusInfoList}
+        close={() => {
           setShowUserInfo(false);
           setFocusedDate(null);
         }}
-      >
-        {focusedDate && (
-          <UserInfoOfDay
-            date={focusedDate}
-            users={users}
-            dateToStatusInfoList={dateToStatusInfoList}
-          />
-        )}
-      </div>
+      />
       <Calendar
         className={showUserInfo ? "calendar-hidden" : ""}
         onClickDay={(date) => {

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -18,7 +18,6 @@ export const GroupCalendar = ({
   );
   const [showUserInfo, setShowUserInfo] = useState(false);
   const [focusedDate, setFocusedDate] = useState<Date | null>(null);
-  // TODO "dd日" ではなく "dd" だけ表示する
   const dateToStatusInfoList: DateTimeToStatusInfoList = {};
 
   for (const userDateStatusList of groupDateStatusList) {

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,3 +1,4 @@
+import { GroupWithId } from "interfaces/Group";
 import React, { useState } from "react";
 import Calendar from "react-calendar";
 import {
@@ -8,10 +9,12 @@ import { UserInfoOfDay } from "./UserInfoOfDay";
 
 interface GroupCalendarProps {
   groupDateStatusList: UserDateStatusList[];
+  group: GroupWithId;
 }
 
 export const GroupCalendar = ({
-  groupDateStatusList: groupDateStatusList,
+  groupDateStatusList,
+  group,
 }: GroupCalendarProps): JSX.Element => {
   const users = groupDateStatusList.map(
     (groupDateStatus) => groupDateStatus.user
@@ -61,6 +64,7 @@ export const GroupCalendar = ({
     <React.Fragment>
       <UserInfoOfDay
         date={focusedDate}
+        groupId={group.id}
         users={users}
         dateToStatusInfoList={dateToStatusInfoList}
         close={() => {

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,22 +1,13 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import Calendar from "react-calendar";
-import { Status, UserDateStatusList } from "../interfaces/DateStatus";
+import {
+  DateTimeToStatusInfoList,
+  UserDateStatusList,
+} from "../interfaces/DateStatus";
+import { UserInfoOfDay } from "./UserInfoOfDay";
 
 interface GroupCalendarProps {
   groupDateStatusList: UserDateStatusList[];
-}
-
-interface UsersStatus {
-  [uid: string]: Status | undefined;
-}
-
-interface StatusInfo {
-  free: number;
-  busy: number;
-  usersStatus: UsersStatus;
-}
-interface DateTimeToStatusInfoList {
-  [dateTime: number]: StatusInfo | undefined;
 }
 
 export const GroupCalendar = ({
@@ -67,48 +58,6 @@ export const GroupCalendar = ({
     }
   };
 
-  // TODO 別ファイルに分ける
-  // TODO きれいに表示する
-  const userInfoComponent = (date: Date): JSX.Element => {
-    const dateTime = date.getTime();
-    const statusInfo = dateToStatusInfoList[dateTime];
-    const userStatusComponents = users.map((user) => {
-      if (statusInfo == null) {
-        return <div key={user.id}>{user.name}: 未入力</div>;
-      } else {
-        const status = statusInfo.usersStatus[user.id];
-        if (status == null) {
-          return <div key={user.id}>{user.name}: 未入力</div>;
-        } else {
-          const statusText = status == "calendar-free" ? "〇" : "×";
-          return (
-            <div key={user.id}>
-              {user.name}: {statusText}
-            </div>
-          );
-        }
-      }
-    });
-    if (statusInfo == null) {
-      return (
-        <React.Fragment>
-          <p>{date.toString()}</p>
-          <p>暇な人: {0}</p>
-          <p>忙しい人: {0}</p>
-          {userStatusComponents}
-        </React.Fragment>
-      );
-    } else {
-      return (
-        <React.Fragment>
-          <p>{date.toString()}</p>
-          <p>暇な人: {statusInfo.free}</p>
-          <p>忙しい人: {statusInfo.busy}</p>
-          {userStatusComponents}
-        </React.Fragment>
-      );
-    }
-  };
   return (
     <React.Fragment>
       <div
@@ -117,7 +66,13 @@ export const GroupCalendar = ({
           setFocusedDate(null);
         }}
       >
-        {focusedDate && userInfoComponent(focusedDate)}
+        {focusedDate && (
+          <UserInfoOfDay
+            date={focusedDate}
+            users={users}
+            dateToStatusInfoList={dateToStatusInfoList}
+          />
+        )}
       </div>
       <Calendar
         className={showUserInfo ? "calendar-hidden" : ""}

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from "react";
-import { Overlay, Tooltip } from "react-bootstrap";
 import Calendar from "react-calendar";
 import { Status, UserDateStatusList } from "../interfaces/DateStatus";
 
@@ -26,9 +25,8 @@ export const GroupCalendar = ({
   const users = groupDateStatusList.map(
     (groupDateStatus) => groupDateStatus.user
   );
-  const calendarRef = useRef(null);
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [focusedDate, setFocusedDate] = useState<Date | undefined>(undefined);
+  const [showUserInfo, setShowUserInfo] = useState(false);
+  const [focusedDate, setFocusedDate] = useState<Date | null>(null);
   // TODO "dd日" ではなく "dd" だけ表示する
   const dateToStatusInfoList: DateTimeToStatusInfoList = {};
 
@@ -71,7 +69,7 @@ export const GroupCalendar = ({
 
   // TODO 別ファイルに分ける
   // TODO きれいに表示する
-  const tooltipComponent = (date: Date): JSX.Element => {
+  const userInfoComponent = (date: Date): JSX.Element => {
     const dateTime = date.getTime();
     const statusInfo = dateToStatusInfoList[dateTime];
     const userStatusComponents = users.map((user) => {
@@ -113,12 +111,19 @@ export const GroupCalendar = ({
   };
   return (
     <React.Fragment>
-      <div></div>
+      <div
+        onClick={() => {
+          setShowUserInfo(false);
+          setFocusedDate(null);
+        }}
+      >
+        {focusedDate && userInfoComponent(focusedDate)}
+      </div>
       <Calendar
-        inputRef={calendarRef}
+        className={showUserInfo ? "calendar-hidden" : ""}
         onClickDay={(date) => {
           setFocusedDate(date);
-          setShowTooltip(true);
+          setShowUserInfo(true);
         }}
         locale="ja-JP"
         minDate={new Date()}
@@ -149,23 +154,6 @@ export const GroupCalendar = ({
           }
         }}
       />
-      <Overlay
-        target={calendarRef.current}
-        show={showTooltip}
-        placement="right"
-      >
-        {(props) => (
-          <Tooltip
-            onClick={() => {
-              setShowTooltip(false);
-            }}
-            id="overlay-example"
-            {...props}
-          >
-            {focusedDate && tooltipComponent(focusedDate)}
-          </Tooltip>
-        )}
-      </Overlay>
     </React.Fragment>
   );
 };

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -146,6 +146,7 @@ export const JoinGroupForm = ({ group }: JoinGroupFormProps): JSX.Element => {
               <Form onSubmit={handleSubmit(confirmJoinGroup)}>
                 <p>{user.name} としてログイン中</p>
                 <p>グループ: {group.name}に参加しますか？</p>
+                <p>グループの説明: {group.description}</p>
                 <Form.Group>
                   <Form.Label>Chat ID</Form.Label>
                   <Form.Control

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -9,15 +9,20 @@ import Layout from "./Layout";
 import Link from "next/link";
 import { LoginForm } from "./LoginForm";
 import { RegisterForm } from "./RegisterForm";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
 
 type Props = {
   group: GroupWithId;
 };
 
-// 現在入力はないがreact-hook-formを用いるために必要
 type InputsType = {
-  empty: undefined;
+  chatId: string;
 };
+
+const schema = yup.object().shape({
+  chatId: yup.string(),
+});
 
 type LoginOrRegister = "login" | "register";
 
@@ -65,22 +70,23 @@ export const JoinGroupForm = ({ group }: Props): JSX.Element => {
   }, [authUser]);
 
   const {
+    register,
     handleSubmit,
     formState: { errors },
     setError,
-  } = useForm<InputsType>();
+  } = useForm<InputsType>({ resolver: yupResolver(schema) });
   const setUnexpectedError = () => {
-    setError("empty", {
+    setError("chatId", {
       type: "manual",
       message: "予期せぬエラーが発生しました！ もう一度お試しください",
     });
   };
 
-  const confirmJoinGroup = async () => {
+  const confirmJoinGroup = async (data: InputsType) => {
     if (user == null) {
       setUnexpectedError();
     } else {
-      joinGroup(user.id, group.id)
+      joinGroup(user.id, group.id, data["chatId"])
         .then(() => {
           Router.push("/");
         })
@@ -140,11 +146,18 @@ export const JoinGroupForm = ({ group }: Props): JSX.Element => {
               <Form onSubmit={handleSubmit(confirmJoinGroup)}>
                 <p>{user.name} としてログイン中</p>
                 <p>グループ: {group.name}に参加しますか？</p>
-                {errors.empty && (
-                  <Form.Control.Feedback type="invalid">
-                    {errors.empty.message}
-                  </Form.Control.Feedback>
-                )}
+                <Form.Group>
+                  <Form.Label>Chat ID</Form.Label>
+                  <Form.Control
+                    isInvalid={!!errors.chatId}
+                    {...register("chatId")}
+                  />
+                  {errors.chatId && (
+                    <Form.Control.Feedback type="invalid">
+                      {errors.chatId.message}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
                 <Button variant="accent" type="submit">
                   参加
                 </Button>

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -12,13 +12,13 @@ import { RegisterForm } from "./RegisterForm";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 
-type Props = {
+interface JoinGroupFormProps {
   group: GroupWithId;
-};
+}
 
-type InputsType = {
+interface InputsType {
   chatId: string;
-};
+}
 
 const schema = yup.object().shape({
   chatId: yup.string(),
@@ -26,7 +26,7 @@ const schema = yup.object().shape({
 
 type LoginOrRegister = "login" | "register";
 
-export const JoinGroupForm = ({ group }: Props): JSX.Element => {
+export const JoinGroupForm = ({ group }: JoinGroupFormProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);
   const [isAlreadyJoined, setIsAlreadyJoined] = useState<boolean | undefined>(
     undefined

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -118,11 +118,7 @@ export const RegisterForm = ({
       </Form.Group>
       <Form.Group>
         <Form.Label>user name</Form.Label>
-        <Form.Control
-          type="userName"
-          isInvalid={!!errors.userName}
-          {...register("userName")}
-        />
+        <Form.Control isInvalid={!!errors.userName} {...register("userName")} />
         {errors.userName && (
           <Form.Control.Feedback type="invalid">
             {errors.userName.message}

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -6,17 +6,17 @@ import { auth } from "../utils/firebase";
 import { storeUser, User } from "../interfaces/User";
 import firebase from "firebase/app";
 
-type InputsType = {
+interface RegisterFormProps {
+  onRegistered?: () => void;
+}
+
+interface InputsType {
   email: string;
   password: string;
   name: string;
   userName: string;
   confirmPassword: string;
-};
-
-type RegisterFormProps = {
-  onRegistered?: () => void;
-};
+}
 
 const schema = yup.object().shape({
   email: yup

--- a/components/UserCalendar.tsx
+++ b/components/UserCalendar.tsx
@@ -26,7 +26,6 @@ export const UserCalendar = ({
     }
   };
 
-  // TODO "dd日" ではなく "dd" だけ表示する
   // TODO 過ぎた日の扱いを決める (e.g. 毎日自動で消す, そのまま残す)
   return (
     <Calendar

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -2,6 +2,7 @@ import { DateTimeToStatusInfoList } from "interfaces/DateStatus";
 import { UserWithId } from "interfaces/User";
 import React from "react";
 import { Button, Card, Table } from "react-bootstrap";
+import { EventMessage } from "./EventMessage";
 
 interface UserInfoOfDayProps {
   date: Date | null;
@@ -51,6 +52,7 @@ export const UserInfoOfDay = ({
       </tr>
     );
   });
+
   const dayFormat = (day: number) => {
     switch (day) {
       case 0:
@@ -71,20 +73,16 @@ export const UserInfoOfDay = ({
         return "Unexpected Error";
     }
   };
-  const dateString = `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}(${dayFormat(
+
+  const dateText = `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}(${dayFormat(
     date.getDay()
   )})`;
 
-  const cardTitleComponent =
-    statusInfo == null ? (
-      <Card.Title>
-        暇な人: {0} 忙しい人: {0}
-      </Card.Title>
-    ) : (
-      <Card.Title>
-        暇な人: {statusInfo.free} 忙しい人: {statusInfo.busy}
-      </Card.Title>
-    );
+  const cardTitleText =
+    statusInfo == null
+      ? `暇な人: 0 忙しい人: 0`
+      : `暇な人: ${statusInfo.free} 忙しい人: ${statusInfo.busy}`;
+
   return (
     <Card>
       <Card.Header as="h4">
@@ -96,10 +94,10 @@ export const UserInfoOfDay = ({
         >
           <span aria-hidden="true">戻る</span>
         </Button>
-        {dateString}
+        {dateText}
       </Card.Header>
       <Card.Body>
-        {cardTitleComponent}
+        <Card.Title>{cardTitleText}</Card.Title>
         <Table striped bordered hover>
           <thead>
             <tr>
@@ -112,7 +110,7 @@ export const UserInfoOfDay = ({
         </Table>
       </Card.Body>
       <Card.Footer>
-        <p>募集メッセージ</p>
+        <EventMessage users={users} />
       </Card.Footer>
     </Card>
   );

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -83,16 +83,15 @@ export const UserInfoOfDay = ({
   return (
     <Card>
       <Card.Header as="h4">
-        {dateString}
         <Button
-          className="float-right"
+          className="float-left mr-3"
           onClick={close}
           size="sm"
           variant="main"
-          aria-label="Close"
         >
-          <span aria-hidden="true">&times;</span>
+          <span aria-hidden="true">戻る</span>
         </Button>
+        {dateString}
       </Card.Header>
       <Card.Body>
         {cardTitleComponent}

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -3,16 +3,21 @@ import { UserWithId } from "interfaces/User";
 import React from "react";
 
 interface UserInfoOfDayProps {
-  date: Date;
+  date: Date | null;
   users: UserWithId[];
   dateToStatusInfoList: DateTimeToStatusInfoList;
+  close: () => void;
 }
 
 export const UserInfoOfDay = ({
   date,
   users,
   dateToStatusInfoList,
+  close,
 }: UserInfoOfDayProps): JSX.Element => {
+  if (date == null) {
+    return <React.Fragment />;
+  }
   const dateTime = date.getTime();
   const statusInfo = dateToStatusInfoList[dateTime];
   const userStatusComponents = users.map((user) => {
@@ -32,23 +37,46 @@ export const UserInfoOfDay = ({
       }
     }
   });
+  const dayFormat = (day: number) => {
+    switch (day) {
+      case 0:
+        return "日";
+      case 1:
+        return "月";
+      case 2:
+        return "火";
+      case 3:
+        return "水";
+      case 4:
+        return "木";
+      case 5:
+        return "金";
+      case 6:
+        return "土";
+      default:
+        return "Unexpected Error";
+    }
+  };
+  const dateString = `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}(${dayFormat(
+    date.getDay()
+  )})`;
   if (statusInfo == null) {
     return (
-      <React.Fragment>
-        <p>{date.toString()}</p>
+      <div onClick={close}>
+        <p>{dateString}</p>
         <p>暇な人: {0}</p>
         <p>忙しい人: {0}</p>
         {userStatusComponents}
-      </React.Fragment>
+      </div>
     );
   } else {
     return (
-      <React.Fragment>
-        <p>{date.toString()}</p>
+      <div onClick={close}>
+        <p>{dateString}</p>
         <p>暇な人: {statusInfo.free}</p>
         <p>忙しい人: {statusInfo.busy}</p>
         {userStatusComponents}
-      </React.Fragment>
+      </div>
     );
   }
 };

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Table } from "react-bootstrap";
 
 interface UserInfoOfDayProps {
   date: Date | null;
+  groupId: string;
   users: UserWithId[];
   dateToStatusInfoList: DateTimeToStatusInfoList;
   close: () => void;
@@ -12,6 +13,7 @@ interface UserInfoOfDayProps {
 
 export const UserInfoOfDay = ({
   date,
+  groupId,
   users,
   dateToStatusInfoList,
   close,
@@ -35,10 +37,12 @@ export const UserInfoOfDay = ({
         return busyText;
       }
     };
+    const chatId = user.groups == null ? "" : user.groups[groupId];
     return (
       <tr key={user.id}>
         <td>{user.name}</td>
         <td>{statusText()}</td>
+        <td>{chatId}</td>
       </tr>
     );
   });
@@ -94,6 +98,13 @@ export const UserInfoOfDay = ({
         {cardTitleComponent}
 
         <Table striped bordered hover>
+          <thead>
+            <tr>
+              <th>ユーザー名</th>
+              <th>予定</th>
+              <th>チャットID</th>
+            </tr>
+          </thead>
           <tbody>{userStatusComponents}</tbody>
         </Table>
       </Card.Body>

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -53,6 +53,30 @@ export const UserInfoOfDay = ({
     );
   });
 
+  const freeUsers = users.filter((user) => {
+    if (statusInfo == null) return false;
+    const status = statusInfo.usersStatus[user.id];
+    return status == "calendar-free";
+  });
+  const freeChatIds = freeUsers
+    .map((freeUser) => {
+      return freeUser.groups == null ? null : freeUser.groups[groupId];
+    })
+    .filter<string>((chatId): chatId is string => chatId != null);
+
+  const unEnteredUsers = users.filter((user) => {
+    if (statusInfo == null) return false;
+    const status = statusInfo.usersStatus[user.id];
+    return status == null;
+  });
+  const unEnteredChatIds = unEnteredUsers
+    .map((unEnteredUser) => {
+      return unEnteredUser.groups == null
+        ? null
+        : unEnteredUser.groups[groupId];
+    })
+    .filter<string>((chatId): chatId is string => chatId != null);
+
   const dayFormat = (day: number) => {
     switch (day) {
       case 0:
@@ -110,7 +134,11 @@ export const UserInfoOfDay = ({
         </Table>
       </Card.Body>
       <Card.Footer>
-        <EventMessage users={users} />
+        <EventMessage
+          dateText={dateText}
+          freeChatIds={freeChatIds}
+          unEnteredChatIds={unEnteredChatIds}
+        />
       </Card.Footer>
     </Card>
   );

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -26,15 +26,20 @@ export const UserInfoOfDay = ({
   const unEnteredText = "未入力";
   const freeText = "〇";
   const busyText = "×";
+  const errorText = "エラー！";
 
   const userStatusComponents = users.map((user) => {
     const statusText = () => {
       if (statusInfo == null) return unEnteredText;
       const status = statusInfo.usersStatus[user.id];
-      if (status == "calendar-free") {
+      if (status == null) {
+        return unEnteredText;
+      } else if (status == "calendar-free") {
         return freeText;
-      } else {
+      } else if (status == "calendar-busy") {
         return busyText;
+      } else {
+        return errorText;
       }
     };
     const chatId = user.groups == null ? "" : user.groups[groupId];
@@ -95,7 +100,6 @@ export const UserInfoOfDay = ({
       </Card.Header>
       <Card.Body>
         {cardTitleComponent}
-
         <Table striped bordered hover>
           <thead>
             <tr>
@@ -107,6 +111,9 @@ export const UserInfoOfDay = ({
           <tbody>{userStatusComponents}</tbody>
         </Table>
       </Card.Body>
+      <Card.Footer>
+        <p>募集メッセージ</p>
+      </Card.Footer>
     </Card>
   );
 };

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -1,6 +1,7 @@
 import { DateTimeToStatusInfoList } from "interfaces/DateStatus";
 import { UserWithId } from "interfaces/User";
 import React from "react";
+import { Button, Card, Table } from "react-bootstrap";
 
 interface UserInfoOfDayProps {
   date: Date | null;
@@ -20,22 +21,26 @@ export const UserInfoOfDay = ({
   }
   const dateTime = date.getTime();
   const statusInfo = dateToStatusInfoList[dateTime];
+  const unEnteredText = "未入力";
+  const freeText = "〇";
+  const busyText = "×";
+
   const userStatusComponents = users.map((user) => {
-    if (statusInfo == null) {
-      return <div key={user.id}>{user.name}: 未入力</div>;
-    } else {
+    const statusText = () => {
+      if (statusInfo == null) return unEnteredText;
       const status = statusInfo.usersStatus[user.id];
-      if (status == null) {
-        return <div key={user.id}>{user.name}: 未入力</div>;
+      if (status == "calendar-free") {
+        return freeText;
       } else {
-        const statusText = status == "calendar-free" ? "〇" : "×";
-        return (
-          <div key={user.id}>
-            {user.name}: {statusText}
-          </div>
-        );
+        return busyText;
       }
-    }
+    };
+    return (
+      <tr key={user.id}>
+        <td>{user.name}</td>
+        <td>{statusText()}</td>
+      </tr>
+    );
   });
   const dayFormat = (day: number) => {
     switch (day) {
@@ -60,23 +65,38 @@ export const UserInfoOfDay = ({
   const dateString = `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}(${dayFormat(
     date.getDay()
   )})`;
-  if (statusInfo == null) {
-    return (
-      <div onClick={close}>
-        <p>{dateString}</p>
-        <p>暇な人: {0}</p>
-        <p>忙しい人: {0}</p>
-        {userStatusComponents}
-      </div>
+
+  const cardTitleComponent =
+    statusInfo == null ? (
+      <Card.Title>
+        暇な人: {0} 忙しい人: {0}
+      </Card.Title>
+    ) : (
+      <Card.Title>
+        暇な人: {statusInfo.free} 忙しい人: {statusInfo.busy}
+      </Card.Title>
     );
-  } else {
-    return (
-      <div onClick={close}>
-        <p>{dateString}</p>
-        <p>暇な人: {statusInfo.free}</p>
-        <p>忙しい人: {statusInfo.busy}</p>
-        {userStatusComponents}
-      </div>
-    );
-  }
+  return (
+    <Card>
+      <Card.Header as="h4">
+        {dateString}
+        <Button
+          className="float-right"
+          onClick={close}
+          size="sm"
+          variant="main"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </Button>
+      </Card.Header>
+      <Card.Body>
+        {cardTitleComponent}
+
+        <Table striped bordered hover>
+          <tbody>{userStatusComponents}</tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  );
 };

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -1,0 +1,54 @@
+import { DateTimeToStatusInfoList } from "interfaces/DateStatus";
+import { UserWithId } from "interfaces/User";
+import React from "react";
+
+interface UserInfoOfDayProps {
+  date: Date;
+  users: UserWithId[];
+  dateToStatusInfoList: DateTimeToStatusInfoList;
+}
+
+export const UserInfoOfDay = ({
+  date,
+  users,
+  dateToStatusInfoList,
+}: UserInfoOfDayProps): JSX.Element => {
+  const dateTime = date.getTime();
+  const statusInfo = dateToStatusInfoList[dateTime];
+  const userStatusComponents = users.map((user) => {
+    if (statusInfo == null) {
+      return <div key={user.id}>{user.name}: 未入力</div>;
+    } else {
+      const status = statusInfo.usersStatus[user.id];
+      if (status == null) {
+        return <div key={user.id}>{user.name}: 未入力</div>;
+      } else {
+        const statusText = status == "calendar-free" ? "〇" : "×";
+        return (
+          <div key={user.id}>
+            {user.name}: {statusText}
+          </div>
+        );
+      }
+    }
+  });
+  if (statusInfo == null) {
+    return (
+      <React.Fragment>
+        <p>{date.toString()}</p>
+        <p>暇な人: {0}</p>
+        <p>忙しい人: {0}</p>
+        {userStatusComponents}
+      </React.Fragment>
+    );
+  } else {
+    return (
+      <React.Fragment>
+        <p>{date.toString()}</p>
+        <p>暇な人: {statusInfo.free}</p>
+        <p>忙しい人: {statusInfo.busy}</p>
+        {userStatusComponents}
+      </React.Fragment>
+    );
+  }
+};

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -14,6 +14,19 @@ export interface UserDateStatusList {
   dateStatusList: DateStatusList;
 }
 
+export interface UsersStatus {
+  [uid: string]: Status | undefined;
+}
+
+export interface StatusInfo {
+  free: number;
+  busy: number;
+  usersStatus: UsersStatus;
+}
+export interface DateTimeToStatusInfoList {
+  [dateTime: number]: StatusInfo | undefined;
+}
+
 export const storeDateStatusList = async (
   dateStatusList: DateStatusList,
   uid: string

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -9,6 +9,7 @@ export interface Group {
     [uid: string]: string;
   };
   invitationId?: string;
+  description: string;
 }
 
 type GroupChild =

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -5,7 +5,8 @@ import firebase from "firebase/app";
 export interface Group {
   name: string;
   members?: {
-    [uid: string]: true;
+    // Chat Id (eg. Slack, Discor, Twitter...)
+    [uid: string]: string;
   };
   invitationId?: string;
 }
@@ -13,20 +14,24 @@ export interface Group {
 type GroupChild =
   | string
   | {
-      [uid: string]: true;
+      [uid: string]: string;
     };
 
 export interface GroupWithId extends Group {
   id: string;
 }
 
-export const storeGroup = async (group: Group, uid: string): Promise<void> => {
+export const storeGroup = async (
+  group: Group,
+  uid: string,
+  chatId: string
+): Promise<void> => {
   const ref = await db.ref().child("groups").push(group);
   const groupId = ref.key;
   if (groupId == null) {
     return Promise.reject("GroupId is null");
   } else {
-    return joinGroup(uid, groupId);
+    return joinGroup(uid, groupId, chatId);
   }
 };
 

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -4,7 +4,8 @@ export interface User {
   name: string;
   email: string;
   groups?: {
-    [groupId: string]: true;
+    // Chat Id (eg. Slack, Discor, Twitter...)
+    [groupId: string]: string;
   };
 }
 
@@ -28,11 +29,12 @@ export const loadUser = async (uid: string): Promise<UserWithId | null> => {
 
 export const joinGroup = async (
   uid: string,
-  groupId: string
+  groupId: string,
+  chatId: string
 ): Promise<void> => {
   const updates = {
-    [`/users/${uid}/groups/${groupId}`]: true,
-    [`/groups/${groupId}/members/${uid}`]: true,
+    [`/users/${uid}/groups/${groupId}`]: chatId,
+    [`/groups/${groupId}/members/${uid}`]: chatId,
   };
   return await db.ref().update(updates);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -100,7 +100,10 @@ const GroupCalendarPage = ({
           <Button variant="accent" type="button" onClick={reload}>
             更新
           </Button>
-          <GroupCalendar groupDateStatusList={groupDateStatusList} />
+          <GroupCalendar
+            groupDateStatusList={groupDateStatusList}
+            group={group}
+          />
           <Link href="/">
             <a>戻る</a>
           </Link>

--- a/styles/sass/calendar.scss
+++ b/styles/sass/calendar.scss
@@ -84,3 +84,7 @@
 .calendar-busy:hover {
   background-color: $main-dark-color !important;
 }
+
+.calendar-hidden {
+  display: none;
+}


### PR DESCRIPTION
# 概要

- グループ作成時に使用するチャットツール(Slack, Discord, twitter, その他)，グループの概要を記入する
- グループ作成時，グループ参加時にチャットツールのID(@含む)を入力させる．
- グループカレンダーの日付をクリックしてevent作成時に暇な人全員に向けたメンションを自動作成．

# 動作確認

![aeb3dc205dc36c195dd0d6f61968170d](https://user-images.githubusercontent.com/43720583/117537724-d6501c00-b03d-11eb-83d7-7e2e8e959306.png)

![50058f55fe4e21ab94869b06f0132d2c](https://user-images.githubusercontent.com/43720583/117537904-b836eb80-b03e-11eb-962a-e62f2508b7cf.png)
