### PR TITLE
ユーザー登録時に確認メールを送信

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 const Layout = ({ children, title = "Default Title" }: Props): JSX.Element => {
-  const authContext = useContext(AuthContext);
+  const { authUser } = useContext(AuthContext);
   const logout = async (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.preventDefault();
     // auth.signOut().then(() => { Router.puth("/") }) とやると他ページの/loginへのリダイレクトが先に働いてしまう
@@ -41,7 +41,7 @@ const Layout = ({ children, title = "Default Title" }: Props): JSX.Element => {
           <Link href="/" passHref>
             <Navbar.Brand className="mr-auto">Hima Share</Navbar.Brand>
           </Link>
-          {authContext.authUser && (
+          {authUser && authUser.emailVerified && (
             <Nav>
               <Link href="/profile" passHref>
                 <Nav.Link className="mr-3" active>
@@ -53,7 +53,7 @@ const Layout = ({ children, title = "Default Title" }: Props): JSX.Element => {
               </Nav.Link>
             </Nav>
           )}
-          {authContext.authUser === null && (
+          {authUser === null && (
             <Nav>
               <Link href="/login" passHref>
                 <Nav.Link active>Login</Nav.Link>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -41,7 +41,7 @@ const Layout = ({ children, title = "Default Title" }: Props): JSX.Element => {
           <Link href="/" passHref>
             <Navbar.Brand className="mr-auto">Hima Share</Navbar.Brand>
           </Link>
-          {authUser && authUser.emailVerified && (
+          {authUser && (
             <Nav>
               <Link href="/profile" passHref>
                 <Nav.Link className="mr-3" active>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -94,7 +94,6 @@ export const RegisterForm = ({
       Promise.all([]);
       const user: User = {
         name: data["name"],
-        email: data["email"],
         description: data["description"],
       };
       await Promise.all([

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -81,32 +81,37 @@ export const RegisterForm = ({
     });
   };
   const registerUser = async (data: InputsType) => {
-    auth
-      .createUserWithEmailAndPassword(data["email"], data["password"])
-      .then(async (userCredential) => {
-        const uid = userCredential.user?.uid;
-        if (uid != null) {
-          const user: User = {
-            name: data["name"],
-            email: data["email"],
-            description: data["description"],
-          };
-          storeUser(user, uid)
-            .then(() => {
-              if (onRegistered != null) {
-                onRegistered();
-              }
-            })
-            .catch(() => {
-              setUnexpectedError();
-            });
-        } else {
-          setUnexpectedError();
-        }
-      })
-      .catch(() => {
+    try {
+      const userCredential = await auth.createUserWithEmailAndPassword(
+        data["email"],
+        data["password"]
+      );
+      const authUser = userCredential.user;
+      if (authUser == null) {
         setUnexpectedError();
-      });
+        return;
+      }
+      Promise.all([]);
+      const user: User = {
+        name: data["name"],
+        email: data["email"],
+        description: data["description"],
+      };
+      await Promise.all([
+        storeUser(user, authUser.uid),
+        authUser.updateProfile({
+          displayName: data["name"],
+        }),
+        authUser.sendEmailVerification({
+          url: `${document.location.origin}`,
+        }),
+      ]);
+      if (onRegistered != null) {
+        onRegistered();
+      }
+    } catch {
+      setUnexpectedError();
+    }
   };
   return (
     <Form onSubmit={handleSubmit(registerUser)}>

--- a/components/UpdateEmailForm.tsx
+++ b/components/UpdateEmailForm.tsx
@@ -4,12 +4,10 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { auth } from "../utils/firebase";
 import firebase from "firebase/app";
-import { updateUser, UserWithId } from "interfaces/User";
 import { useContext } from "react";
 import { AuthContext } from "context/AuthContext";
 
 interface UpdateEmailFormProps {
-  user: UserWithId;
   onUpdated?: (newEmail: string) => void;
 }
 
@@ -52,7 +50,6 @@ const schema = yup.object().shape({
 });
 
 export const UpdateEmailForm = ({
-  user,
   onUpdated,
 }: UpdateEmailFormProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);
@@ -74,10 +71,7 @@ export const UpdateEmailForm = ({
       setUnexpectedError();
     } else {
       try {
-        await Promise.all([
-          authUser.updateEmail(data["email"]),
-          updateUser(user, undefined, data["email"], undefined),
-        ]);
+        await Promise.all([authUser.updateEmail(data["email"])]);
         await authUser.sendEmailVerification({
           url: `${document.location.origin}`,
         });

--- a/components/UpdateEmailForm.tsx
+++ b/components/UpdateEmailForm.tsx
@@ -73,18 +73,20 @@ export const UpdateEmailForm = ({
     if (authUser == null) {
       setUnexpectedError();
     } else {
-      Promise.all([
-        authUser.updateEmail(data["email"]),
-        updateUser(user, undefined, data["email"], undefined),
-      ])
-        .then(() => {
-          if (onUpdated != null) {
-            onUpdated(data["email"]);
-          }
-        })
-        .catch(() => {
-          setUnexpectedError();
+      try {
+        await Promise.all([
+          authUser.updateEmail(data["email"]),
+          updateUser(user, undefined, data["email"], undefined),
+        ]);
+        await authUser.sendEmailVerification({
+          url: `${document.location.origin}`,
         });
+        if (onUpdated != null) {
+          onUpdated(data["email"]);
+        }
+      } catch {
+        setUnexpectedError();
+      }
     }
   };
   // TODO エラーメッセージがなぜかでない？

--- a/components/UpdateUserForm.tsx
+++ b/components/UpdateUserForm.tsx
@@ -49,7 +49,7 @@ export const UpdateUserForm = ({
     if (authUser == null) {
       setUnexpectedError();
     } else {
-      updateUser(user, data["name"], undefined, data["description"])
+      updateUser(user, data["name"], data["description"])
         .then(() => {
           setShowTooltip(true);
         })

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -3,7 +3,6 @@ import { deleteGroup, GroupWithId, loadGroup } from "./Group";
 
 export interface User {
   name: string;
-  email: string;
   groups?: {
     // Chat Id (eg. Slack, Discor, Twitter...)
     [groupId: string]: string | undefined;
@@ -44,12 +43,10 @@ export const joinGroup = async (
 export const updateUser = async (
   user: UserWithId,
   name?: string,
-  email?: string,
   description?: string
 ): Promise<void> => {
   const updateUser = {
     name: name ? name : user.name,
-    email: email ? email : user.email,
     description: description ? description : user.description,
   };
   const updates = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -10,11 +10,13 @@ const CreateGroupPage = (): JSX.Element => {
   useEffect(() => {
     if (authUser === null) {
       Router.push("/login");
+    } else if (authUser != null && !authUser.emailVerified) {
+      Router.push("/email-verify");
     }
   }, [authUser]);
   return (
     <React.Fragment>
-      {authUser && (
+      {authUser && !(authUser != null && !authUser.emailVerified) && (
         <Layout title="Create Group">
           <h1>Create Group</h1>
           <CreateGroupForm />

--- a/pages/email-verify.tsx
+++ b/pages/email-verify.tsx
@@ -1,0 +1,47 @@
+import Layout from "components/Layout";
+import { AuthContext } from "context/AuthContext";
+import Link from "next/link";
+import Router from "next/router";
+import { useContext, useEffect } from "react";
+import { Button, Row } from "react-bootstrap";
+
+const EmailVerifyPage = (): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  useEffect(() => {
+    if (authUser === null) {
+      Router.push("/login");
+    } else if (authUser != null && authUser.emailVerified) {
+      Router.push("/");
+    }
+  }, [authUser]);
+  const sendVerifyMail = () => {
+    if (authUser != null) {
+      try {
+        authUser.sendEmailVerification({
+          url: `${document.location.origin}`,
+        });
+      } catch {
+        console.error("Unexpected Error");
+      }
+    }
+  };
+  return (
+    <Layout title="メールアドレス確認">
+      <Row className="justify-content-center">
+        <h1>確認メールを送信しました</h1>
+      </Row>
+      <Row className="justify-content-center">
+        <h2>確認メール内のリンクをクリックして下さい</h2>
+      </Row>
+      <Row className="justify-content-center">
+        <Button onClick={sendVerifyMail}>確認メールを再送する</Button>
+      </Row>
+      <Row className="justify-content-center">
+        <Link href="/profile">
+          <a>メールアドレスを変更する</a>
+        </Link>
+      </Row>
+    </Layout>
+  );
+};
+export default EmailVerifyPage;

--- a/pages/email-verify.tsx
+++ b/pages/email-verify.tsx
@@ -2,7 +2,7 @@ import Layout from "components/Layout";
 import { AuthContext } from "context/AuthContext";
 import Link from "next/link";
 import Router from "next/router";
-import { useContext, useEffect } from "react";
+import React, { useContext, useEffect } from "react";
 import { Button, Row } from "react-bootstrap";
 
 const EmailVerifyPage = (): JSX.Element => {
@@ -26,22 +26,26 @@ const EmailVerifyPage = (): JSX.Element => {
     }
   };
   return (
-    <Layout title="メールアドレス確認">
-      <Row className="justify-content-center">
-        <h1>確認メールを送信しました</h1>
-      </Row>
-      <Row className="justify-content-center">
-        <h2>確認メール内のリンクをクリックして下さい</h2>
-      </Row>
-      <Row className="justify-content-center">
-        <Button onClick={sendVerifyMail}>確認メールを再送する</Button>
-      </Row>
-      <Row className="justify-content-center">
-        <Link href="/profile">
-          <a>メールアドレスを変更する</a>
-        </Link>
-      </Row>
-    </Layout>
+    <React.Fragment>
+      {authUser != null && (
+        <Layout title="メールアドレス確認">
+          <Row className="justify-content-center">
+            <h2>{authUser.email}に確認メールを送信しました</h2>
+          </Row>
+          <Row className="justify-content-center">
+            <h3>確認メール内のリンクをクリックして下さい</h3>
+          </Row>
+          <Row className="justify-content-center">
+            <Button onClick={sendVerifyMail}>確認メールを再送する</Button>
+          </Row>
+          <Row className="justify-content-center">
+            <Link href="/profile">
+              <a>メールアドレスを変更する</a>
+            </Link>
+          </Row>
+        </Layout>
+      )}
+    </React.Fragment>
   );
 };
 export default EmailVerifyPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import { GroupList } from "components/GroupList";
 import { GroupWithId, loadGroup } from "interfaces/Group";
 import { loadUser, UserWithId } from "interfaces/User";
 import Link from "next/link";
+import Router from "next/router";
 import React from "react";
 import { useContext, useEffect, useState } from "react";
 import { Row } from "react-bootstrap";
@@ -24,6 +25,9 @@ const IndexPage = (): JSX.Element => {
     undefined
   );
   useEffect(() => {
+    if (authUser != null && !authUser.emailVerified) {
+      Router.push("/email-verify");
+    }
     // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
     let unmounted = false;
     const setFromDatabase = async () => {
@@ -123,7 +127,7 @@ const IndexPage = (): JSX.Element => {
           </p>
         </Layout>
       )}
-      {dateStatusList && user && groups && (
+      {dateStatusList && user && groups && authUser?.emailVerified && (
         <Layout title="ユーザーカレンダー">
           <Row className="justify-content-center">
             <h1>{user.name}のカレンダー</h1>

--- a/pages/join/[invitationId].tsx
+++ b/pages/join/[invitationId].tsx
@@ -2,9 +2,11 @@ import { GetServerSideProps } from "next";
 import { ErrorPage } from "../../components/ErrorPage";
 import { loadInvitation } from "../../interfaces/Invitation";
 import { GroupWithId, loadGroup } from "../../interfaces/Group";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import { JoinGroupForm } from "../../components/JoinGroupForm";
 import Layout from "components/Layout";
+import { AuthContext } from "context/AuthContext";
+import Router from "next/router";
 
 type Props = {
   group?: GroupWithId;
@@ -12,6 +14,13 @@ type Props = {
 };
 
 const JoinGroupPage = ({ group, errors }: Props): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  useEffect(() => {
+    if (authUser != null && !authUser.emailVerified) {
+      Router.push("/email-verify");
+    }
+  }, [authUser]);
+
   if (errors) {
     return <ErrorPage errorMessage={errors} />;
   }
@@ -20,9 +29,14 @@ const JoinGroupPage = ({ group, errors }: Props): JSX.Element => {
   }
 
   return (
-    <Layout title={`${group.name}に参加`}>
-      <JoinGroupForm group={group} />
-    </Layout>
+    <React.Fragment>
+      {authUser !== undefined &&
+        !(authUser != null && !authUser.emailVerified) && (
+          <Layout title={`${group.name}に参加`}>
+            <JoinGroupForm group={group} />
+          </Layout>
+        )}
+    </React.Fragment>
   );
 };
 

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -85,10 +85,12 @@ const ProfilePage = (): JSX.Element => {
         <Layout title="更新完了">
           <Row className="justify-content-center">
             <h2>
-              {updated == "updateEmail" &&
-                "メールアドレスを更新しました(確認メール内のリンクをクリックしてください)"}
+              {updated == "updateEmail" && "メールアドレスを更新しました"}
               {updated == "updatePassword" && "パスワードを更新しました"}
             </h2>
+            {updated == "updateEmail" && (
+              <h3>確認メール内のリンクをクリックして下さい</h3>
+            )}
           </Row>
           <Row className="justify-content-center">
             <Button

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -5,6 +5,7 @@ import { UpdateEmailForm } from "components/UpdateEmailForm";
 import { UpdatePasswordForm } from "components/UpdatePasswordForm";
 import { UpdateUserForm } from "components/UpdateUserForm";
 import Router from "next/router";
+import Link from "next/link";
 import React, { useEffect, useContext, useState } from "react";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import Layout from "../components/Layout";
@@ -209,6 +210,17 @@ const ProfilePage = (): JSX.Element => {
               <Form.Control value={user.email} readOnly />
             </Col>
           </Row>
+          {authUser != null && !authUser.emailVerified && (
+            <Row className="justify-content-center">
+              <Form.Text>
+                メールアドレスが未確認です！
+                <Link href="/email-verify">
+                  <a>確認</a>
+                </Link>
+                して下さい！
+              </Form.Text>
+            </Row>
+          )}
           <Row className="justify-content-center">
             <Button
               variant="accent"

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -85,7 +85,8 @@ const ProfilePage = (): JSX.Element => {
         <Layout title="更新完了">
           <Row className="justify-content-center">
             <h2>
-              {updated == "updateEmail" && "メールアドレスを更新しました"}
+              {updated == "updateEmail" &&
+                "メールアドレスを更新しました(確認メール内のリンクをクリックしてください)"}
               {updated == "updatePassword" && "パスワードを更新しました"}
             </h2>
           </Row>

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -111,14 +111,8 @@ const ProfilePage = (): JSX.Element => {
         <Layout title="メールアドレス更新">
           <Row className="justify-content-center">
             <UpdateEmailForm
-              user={user}
-              onUpdated={(newEmail) => {
+              onUpdated={() => {
                 setReadyUpdateEmail(false);
-                const newUser: UserWithId = {
-                  ...user,
-                  email: newEmail,
-                };
-                setUser(newUser);
                 setUpdated("updateEmail");
               }}
             />
@@ -207,7 +201,14 @@ const ProfilePage = (): JSX.Element => {
           </Row>
           <Row className="justify-content-center">
             <Col md={6}>
-              <Form.Control value={user.email} readOnly />
+              <Form.Control
+                value={
+                  authUser != null && authUser.email != null
+                    ? authUser.email
+                    : ""
+                }
+                readOnly
+              />
             </Col>
           </Row>
           {authUser != null && !authUser.emailVerified && (

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -21,7 +21,7 @@ const RegisterPage = (): JSX.Element => {
             <h1>アカウント作成</h1>
           </Row>
           <Row className="justify-content-center">
-            <RegisterForm onRegistered={() => Router.push("/")} />
+            <RegisterForm onRegistered={() => Router.push("/email-verify")} />
           </Row>
           <Row className="justify-content-center">
             <p>アカウントをお持ちですか？</p>


### PR DESCRIPTION
# 概要

- アカウント作成時，メールアドレス変更時に確認メールを送りそのリンクをクリックしないとプロフィールページ以外を使えないようにした
- User インタフェースからメールアドレスを抜いた
  - メールアドレス変更を中止した際にUserを変えられないため
  - メールアドレスの取得は現状authUserからで十分
参考: [\[JS\] Firebaseの覚書 ① メールアドレス認証 – WebTecNote](https://tenderfeel.xsrv.jp/javascript/3606/)

# 動作確認

![889690a35c5f0cf1415b31fc7a54a095](https://user-images.githubusercontent.com/43720583/117816025-0814ed00-b2a1-11eb-8d1f-ddedbe6e3309.png)

![b97af9b18bb7c3a5acd991bbedfcda43](https://user-images.githubusercontent.com/43720583/117816033-09461a00-b2a1-11eb-97d4-3b4cc41b2fc1.png)


