### PR TITLE
パスワード再設定機能の追加

### DIFF
--- a/components/SendResetPasswordMailForm.tsx
+++ b/components/SendResetPasswordMailForm.tsx
@@ -1,0 +1,84 @@
+import { useForm } from "react-hook-form";
+import { Form, Button, Overlay, Tooltip } from "react-bootstrap";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { auth } from "../utils/firebase";
+import React, { useContext, useRef, useState } from "react";
+import { AuthContext } from "context/AuthContext";
+
+interface InputsType {
+  email: string;
+}
+
+const schema = yup.object().shape({
+  email: yup
+    .string()
+    .email("メールアドレスの形式に誤りがあります")
+    .required("メールアドレスは必須です"),
+});
+
+export const SendResetPasswordMailForm = (): JSX.Element => {
+  const { authUser } = useContext(AuthContext);
+  const buttonRef = useRef(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<InputsType>({ resolver: yupResolver(schema) });
+  const setUnexpectedError = () => {
+    setError("email", {
+      type: "manual",
+      message: "予期せぬエラーが発生しました！ もう一度お試しください",
+    });
+  };
+
+  const sendResetMail = async (data: InputsType) => {
+    if (authUser != null) {
+      setUnexpectedError();
+    } else {
+      try {
+        await auth.sendPasswordResetEmail(data["email"]);
+        setShowTooltip(true);
+      } catch {
+        setUnexpectedError();
+      }
+    }
+  };
+  // TODO エラーメッセージがなぜかでない？
+  return (
+    <Form onSubmit={handleSubmit(sendResetMail)}>
+      <Form.Group>
+        <Form.Label>あなたのメールアドレス</Form.Label>
+        <Form.Control
+          type="email"
+          isInvalid={!!errors.email}
+          {...register("email")}
+        />
+        {errors.email && (
+          <Form.Control.Feedback type="invalid">
+            {errors.email.message}
+          </Form.Control.Feedback>
+        )}
+      </Form.Group>
+      <Button
+        ref={buttonRef}
+        variant="accent"
+        type="submit"
+        onBlur={() => {
+          setShowTooltip(false);
+        }}
+      >
+        送信
+      </Button>
+      <Overlay target={buttonRef.current} show={showTooltip} placement="top">
+        {(props) => (
+          <Tooltip id="event-message-tooltip" {...props}>
+            送信しました！
+          </Tooltip>
+        )}
+      </Overlay>
+    </Form>
+  );
+};

--- a/components/SendResetPasswordMailForm.tsx
+++ b/components/SendResetPasswordMailForm.tsx
@@ -74,7 +74,7 @@ export const SendResetPasswordMailForm = (): JSX.Element => {
       </Button>
       <Overlay target={buttonRef.current} show={showTooltip} placement="top">
         {(props) => (
-          <Tooltip id="event-message-tooltip" {...props}>
+          <Tooltip id="send-mail-tooltip" {...props}>
             送信しました！
           </Tooltip>
         )}

--- a/components/UpdateEmailForm.tsx
+++ b/components/UpdateEmailForm.tsx
@@ -71,7 +71,7 @@ export const UpdateEmailForm = ({
       setUnexpectedError();
     } else {
       try {
-        await Promise.all([authUser.updateEmail(data["email"])]);
+        await authUser.updateEmail(data["email"]);
         await authUser.sendEmailVerification({
           url: `${document.location.origin}`,
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Router from "next/router";
 import React, { useEffect, useContext, useState } from "react";
 import { Row } from "react-bootstrap";
-import { auth } from "utils/firebase";
 import Layout from "../components/Layout";
 import { LoginForm } from "../components/LoginForm";
 import { AuthContext } from "../context/AuthContext";

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,35 +1,74 @@
+import { SendResetPasswordMailForm } from "components/SendResetPasswordMailForm";
 import Link from "next/link";
 import Router from "next/router";
-import React, { useEffect, useContext } from "react";
+import React, { useEffect, useContext, useState } from "react";
 import { Row } from "react-bootstrap";
+import { auth } from "utils/firebase";
 import Layout from "../components/Layout";
 import { LoginForm } from "../components/LoginForm";
 import { AuthContext } from "../context/AuthContext";
 
 const LoginPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
+  const [showResetPasswordForm, setShowResetPasswordForm] = useState(false);
   useEffect(() => {
     if (authUser != null) {
       Router.push("/");
     }
   }, [authUser]);
+
   return (
     <React.Fragment>
       {authUser === null && (
-        <Layout title="Login">
-          <Row className="justify-content-center">
-            <h1>ログイン</h1>
-          </Row>
-          <Row className="justify-content-center">
-            <LoginForm onLogined={() => Router.push("/")} />
-          </Row>
-          <Row className="justify-content-center mt-2">
-            <p> まだ登録していませんか?</p>
-            <Link href="/register">
-              <a>登録</a>
-            </Link>
-          </Row>
-        </Layout>
+        <React.Fragment>
+          {showResetPasswordForm && (
+            <Layout title="パスワードをリセット">
+              <Row className="justify-content-center">
+                <h1>パスワードの再設定</h1>
+              </Row>
+              <Row className="justify-content-center mt-2">
+                <SendResetPasswordMailForm />
+              </Row>
+              <Row className="justify-content-center mt-2">
+                <a
+                  href="#"
+                  onClick={() => {
+                    setShowResetPasswordForm(false);
+                  }}
+                >
+                  戻る
+                </a>
+              </Row>
+            </Layout>
+          )}
+          {!showResetPasswordForm && (
+            <Layout title="ログイン">
+              <Row className="justify-content-center">
+                <h1>ログイン</h1>
+              </Row>
+              <Row className="justify-content-center">
+                <LoginForm onLogined={() => Router.push("/")} />
+              </Row>
+              <Row className="justify-content-center mt-2">
+                <p>まだ登録していませんか?</p>
+                <Link href="/register">
+                  <a>登録</a>
+                </Link>
+              </Row>
+              <Row className="justify-content-center mt-2">
+                <p>パスワードを忘れた場合: </p>
+                <a
+                  href="#"
+                  onClick={() => {
+                    setShowResetPasswordForm(true);
+                  }}
+                >
+                  再設定する
+                </a>
+              </Row>
+            </Layout>
+          )}
+        </React.Fragment>
       )}
     </React.Fragment>
   );

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -144,6 +144,17 @@ const ProfilePage = (): JSX.Element => {
               }}
             />
           </Row>
+          <Row className="justify-content-center mt-3">
+            <a
+              href="#"
+              onClick={() => {
+                setOnLoginedAction(undefined);
+                setReadyDeleteUser(false);
+              }}
+            >
+              戻る
+            </a>
+          </Row>
         </Layout>
       )}
       {onLoginedAction != null &&
@@ -164,6 +175,16 @@ const ProfilePage = (): JSX.Element => {
                   }
                 }}
               />
+            </Row>
+            <Row className="justify-content-center">
+              <a
+                href="#"
+                onClick={() => {
+                  setOnLoginedAction(undefined);
+                }}
+              >
+                戻る
+              </a>
             </Row>
           </Layout>
         )}


### PR DESCRIPTION
# 概要

- ログインページからパスワードの再設定を行えるようにした
  - firebaseの機能: [Firebase でユーザーを管理する](https://firebase.google.com/docs/auth/web/manage-users#send_a_password_reset_email)
  - パスワードのバリデーションができないのが課題

# 動作確認

![8e27f04292a065ffc56575126af92e0b](https://user-images.githubusercontent.com/43720583/118127808-1ac02b00-b435-11eb-9a32-de423e5dd439.png)

![69af768e214fdab86dbfda554db56bdd](https://user-images.githubusercontent.com/43720583/118127768-10059600-b435-11eb-9cd9-c3ecd3958665.png)


