### PR TITLE
ユーザー情報を更新したらグループ参加状況がリセットされるバグを修正

### DIFF
--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -47,6 +47,7 @@ export const updateUser = async (
 ): Promise<void> => {
   const newUser = {
     name: name ? name : user.name,
+    groups: user.groups ? user.groups : null,
     description: description ? description : user.description,
   };
   const updates = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,6 +17,7 @@ const MyApp = ({ Component, pageProps }: AppProps): JSX.Element => {
   const url = typeof window !== "undefined" ? document.location.href : "";
   const origin = typeof window !== "undefined" ? document.location.origin : "";
   const twiiterId = process.env.NEXT_PUBLIC_TWITTER_ID;
+
   useEffect(() => {
     auth.onAuthStateChanged((u) => {
       setAuthUser(u);


### PR DESCRIPTION
# 概要

ユーザー情報を更新したらグループ参加状況がリセットされるバグを修正しました#90 


# 動作確認
