### PR TITLE
お問い合わせページのメールアドレスを難読化

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-calendar": "^3.4.0",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.3.6",
+    "react-obfuscate": "^3.6.8",
     "sass": "^1.32.12",
     "yup": "^0.32.9"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,5 +1,6 @@
 import { Layout } from "components/Layout";
 import { MyHead } from "components/MyHead";
+import Obfuscate from "react-obfuscate";
 
 const PrivacyPolicyPage = (): JSX.Element => {
   const url = typeof window !== "undefined" ? document.location.origin : "";
@@ -34,7 +35,7 @@ const PrivacyPolicyPage = (): JSX.Element => {
       <h2>お問い合わせ</h2>
       <p>
         本ポリシーに関するお問い合せは下記までご連絡ください。
-        <br />⇒<a href="mailto:bana.titech@gmail.com">bana.titech@gmail.com</a>
+        <br />⇒<Obfuscate email="bana.titech@gmail.com" />
       </p>
     </Layout>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "target": "esnext",
     "baseUrl": "./",
     "paths": {
-      "react-calendar": ["./types/react-calendar"]
+      "react-calendar": ["./types/react-calendar"],
+      "react-obfuscate": ["./types/react-obfuscate"]
     },
     "typeRoots": ["./types", "./node_modules/@types"]
   },

--- a/types/react-obfuscate/index.d.ts
+++ b/types/react-obfuscate/index.d.ts
@@ -1,0 +1,34 @@
+interface headersType {
+  cc: string;
+  bcc: string;
+  subject: string;
+  body: string;
+}
+
+interface ObfuscateProps {
+  email?: string | null;
+  headers?: headersType | null;
+  tel?: string | null;
+  sms?: string | null;
+  facetime?: string | null;
+  href?: string | null;
+  linkText?: string;
+  obfuscate?: boolean;
+  obfuscateChildren?: boolean;
+  element?: string;
+  onClick?: function;
+}
+
+export default function Obfuscate({
+  email = null,
+  headers = null,
+  tel = null,
+  sms = null,
+  facetime = null,
+  href = null,
+  linkText = "obfuscated",
+  obfuscate = true,
+  obfuscateChildren = true,
+  element = "a",
+  onClick = null,
+}: ObfuscateProps): JSX.Element;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,6 +2812,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-obfuscate@^3.6.8:
+  version "3.6.8"
+  resolved "https://registry.yarnpkg.com/react-obfuscate/-/react-obfuscate-3.6.8.tgz#31deede7ad8e69672165ec38b4d662135c6bdb5f"
+  integrity sha512-Pc47sbOJEGqOQ65y22ZFwCGHlSwGn0tykl+sQ64wHy/ALcyZxK6zsNYD8Fp3YBcU2EhmJPSKR7BypBYtnAqqyA==
+
 react-overlays@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-5.0.1.tgz#7e2c3cd3c0538048b0b7451d203b1289c561b7f2"


### PR DESCRIPTION
# 概要

- お問い合わせページのメールアドレスを [coston/react\-obfuscate: An intelligent React component to obfuscate any contact link\!](https://github.com/coston/react-obfuscate) を使って難読化した
