### PR TITLE
Userカレンダーの更新時に昨日以前のデータを削除

### DIFF
--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -31,6 +31,19 @@ export const storeDateStatusList = async (
   dateStatusList: DateStatusList,
   uid: string
 ): Promise<void> => {
+  const dateList = Object.keys(dateStatusList);
+  const now = new Date();
+  const yesterdayNumber = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() - 1
+  ).getTime();
+  for (const date of dateList) {
+    const dateNumber = Number(date);
+    if (dateNumber <= yesterdayNumber) {
+      delete dateList[dateNumber];
+    }
+  }
   return db.ref(`calendars/${uid}`).set(dateStatusList);
 };
 
@@ -39,7 +52,21 @@ export const loadDateStatusList = async (
 ): Promise<DateStatusList> => {
   const snapShot = await db.ref().child("calendars").child(uid).once("value");
   if (snapShot.exists()) {
-    return snapShot.val() as DateStatusList;
+    const dateStatusList = snapShot.val() as DateStatusList;
+    const dateList = Object.keys(dateStatusList);
+    const now = new Date();
+    const yesterdayNumber = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - 1
+    ).getTime();
+    for (const date of dateList) {
+      const dateNumber = Number(date);
+      if (dateNumber <= yesterdayNumber) {
+        delete dateList[dateNumber];
+      }
+    }
+    return dateStatusList;
   } else {
     return [];
   }

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -53,19 +53,6 @@ export const loadDateStatusList = async (
   const snapShot = await db.ref().child("calendars").child(uid).once("value");
   if (snapShot.exists()) {
     const dateStatusList = snapShot.val() as DateStatusList;
-    const dateList = Object.keys(dateStatusList);
-    const now = new Date();
-    const yesterdayNumber = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate() - 1
-    ).getTime();
-    for (const date of dateList) {
-      const dateNumber = Number(date);
-      if (dateNumber <= yesterdayNumber) {
-        delete dateList[dateNumber];
-      }
-    }
     return dateStatusList;
   } else {
     return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
# 概要

- Userカレンダーの更新時に昨日以前のデータを削除してから更新するように変更
- 本当は定期的に削除したいがcron job的なことがfirebase無料プランではできない
