### PR TITLE
UserCalendarで曜日の状態を一括変更

### DIFF
--- a/components/UserCalendar.tsx
+++ b/components/UserCalendar.tsx
@@ -18,15 +18,36 @@ export const UserCalendar = ({
     const dateTime = date.getTime();
     const status = dateStatusList[dateTime];
 
-    if (status == null) {
-      dateStatusList[dateTime] = "calendar-free";
-      setDateStatusList({ ...dateStatusList });
-    } else if (status == "calendar-free") {
-      dateStatusList[dateTime] = "calendar-busy";
-      setDateStatusList({ ...dateStatusList });
+    const weekDay = dateTimeToWeekDay(dateTime);
+    const weekDayStatus = dateStatusList[weekDay];
+
+    if (weekDayStatus == "calendar-free") {
+      if (status == "calendar-busy") {
+        delete dateStatusList[dateTime];
+        setDateStatusList({ ...dateStatusList });
+      } else {
+        dateStatusList[dateTime] = "calendar-busy";
+        setDateStatusList({ ...dateStatusList });
+      }
+    } else if (weekDayStatus == "calendar-busy") {
+      if (status == "calendar-free") {
+        delete dateStatusList[dateTime];
+        setDateStatusList({ ...dateStatusList });
+      } else {
+        dateStatusList[dateTime] = "calendar-free";
+        setDateStatusList({ ...dateStatusList });
+      }
     } else {
-      delete dateStatusList[dateTime];
-      setDateStatusList({ ...dateStatusList });
+      if (status == "calendar-free") {
+        dateStatusList[dateTime] = "calendar-busy";
+        setDateStatusList({ ...dateStatusList });
+      } else if (status == "calendar-busy") {
+        delete dateStatusList[dateTime];
+        setDateStatusList({ ...dateStatusList });
+      } else {
+        dateStatusList[dateTime] = "calendar-free";
+        setDateStatusList({ ...dateStatusList });
+      }
     }
   };
 

--- a/components/UserCalendar.tsx
+++ b/components/UserCalendar.tsx
@@ -1,5 +1,9 @@
 import Calendar from "react-calendar";
-import { Status, DateStatusList } from "../interfaces/DateStatus";
+import {
+  Status,
+  DateStatusList,
+  dateTimeToWeekDay,
+} from "../interfaces/DateStatus";
 
 type UserCalendarProps = {
   dateStatusList: DateStatusList;
@@ -45,11 +49,11 @@ export const UserCalendar = ({
       tileClassName={({ date }): Status | null => {
         const dateTime = date.getTime();
         const status = dateStatusList[dateTime];
-        if (status == null) {
-          return null;
-        } else {
-          return status;
-        }
+        if (status != null) return status;
+        const weekDay = dateTimeToWeekDay(dateTime);
+        const weekDayStatus = dateStatusList[weekDay];
+        if (weekDayStatus != null) return weekDayStatus;
+        return null;
       }}
     />
   );

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -1,5 +1,8 @@
-import { DateTimeToStatusInfoList } from "interfaces/DateStatus";
-import { UserWithId } from "interfaces/User";
+import {
+  dateTimeToWeekDay,
+  StatusInfo,
+  UserDateStatusList,
+} from "interfaces/DateStatus";
 import React from "react";
 import { Button, Card, Table } from "react-bootstrap";
 import { EventMessage } from "./EventMessage";
@@ -8,8 +11,7 @@ interface UserInfoOfDayProps {
   date: Date | null;
   groupId: string;
   invitationId?: string;
-  users: UserWithId[];
-  dateToStatusInfoList: DateTimeToStatusInfoList;
+  groupDateStatusList: UserDateStatusList[];
   close: () => void;
 }
 
@@ -17,15 +19,35 @@ export const UserInfoOfDay = ({
   date,
   groupId,
   invitationId,
-  users,
-  dateToStatusInfoList,
+  groupDateStatusList,
   close,
 }: UserInfoOfDayProps): JSX.Element => {
   if (date == null) {
     return <React.Fragment />;
   }
+  const users = groupDateStatusList.map(
+    (groupDateStatus) => groupDateStatus.user
+  );
   const dateTime = date.getTime();
-  const statusInfo = dateToStatusInfoList[dateTime];
+  const weekDay = dateTimeToWeekDay(dateTime);
+  const statusInfo: StatusInfo = {
+    free: 0,
+    busy: 0,
+    usersStatus: {},
+  };
+  for (const userDateStatusList of groupDateStatusList) {
+    const user = userDateStatusList.user;
+    const dateStatusList = userDateStatusList.dateStatusList;
+    const status = dateStatusList[dateTime] || dateStatusList[weekDay];
+    if (status == "calendar-free") {
+      statusInfo.free += 1;
+    } else if (status == "calendar-busy") {
+      statusInfo.busy += 1;
+    }
+    if (status != null) {
+      statusInfo.usersStatus[user.id] = status;
+    }
+  }
   const unEnteredText = "未入力";
   const freeText = "〇";
   const busyText = "×";

--- a/components/WeekDayButtons.tsx
+++ b/components/WeekDayButtons.tsx
@@ -1,5 +1,5 @@
-import { Button, Col, Overlay, Row, Tooltip } from "react-bootstrap";
-import { Status, DateStatusList } from "../interfaces/DateStatus";
+import { Button, Col, Row } from "react-bootstrap";
+import { DateStatusList, WeekDay } from "../interfaces/DateStatus";
 
 interface WeekDayButtonsProps {
   dateStatusList: DateStatusList;
@@ -10,7 +10,7 @@ export const WeekDayButtons = ({
   dateStatusList,
   setDateStatusList,
 }: WeekDayButtonsProps): JSX.Element => {
-  const weekDays = [
+  const weekDays: { id: WeekDay; label: string }[] = [
     {
       id: "mon",
       label: "月",
@@ -41,15 +41,43 @@ export const WeekDayButtons = ({
     },
   ];
 
+  const weekDayIdToVariant = (
+    weekDayId: WeekDay
+  ): "accent" | "main" | "secondary" => {
+    const status = dateStatusList[weekDayId];
+    if (status == "calendar-free") {
+      return "accent";
+    } else if (status == "calendar-busy") {
+      return "main";
+    } else {
+      return "secondary";
+    }
+  };
+
+  const updateDateStatusList = async (weekDay: WeekDay) => {
+    const status = dateStatusList[weekDay];
+
+    if (status == null) {
+      dateStatusList[weekDay] = "calendar-free";
+      setDateStatusList({ ...dateStatusList });
+    } else if (status == "calendar-free") {
+      dateStatusList[weekDay] = "calendar-busy";
+      setDateStatusList({ ...dateStatusList });
+    } else {
+      delete dateStatusList[weekDay];
+      setDateStatusList({ ...dateStatusList });
+    }
+  };
+
   return (
     <Row>
       {weekDays.map((weekDay) => {
         return (
           <Col key={weekDay.id} className="p-1">
             <Button
-              variant="secondary"
+              variant={weekDayIdToVariant(weekDay.id)}
               onClick={() => {
-                console.log(weekDay.id);
+                updateDateStatusList(weekDay.id);
               }}
             >
               {weekDay.label}

--- a/components/WeekDayButtons.tsx
+++ b/components/WeekDayButtons.tsx
@@ -1,0 +1,62 @@
+import { Button, Col, Overlay, Row, Tooltip } from "react-bootstrap";
+import { Status, DateStatusList } from "../interfaces/DateStatus";
+
+interface WeekDayButtonsProps {
+  dateStatusList: DateStatusList;
+  setDateStatusList: (list: DateStatusList) => void;
+}
+
+export const WeekDayButtons = ({
+  dateStatusList,
+  setDateStatusList,
+}: WeekDayButtonsProps): JSX.Element => {
+  const weekDays = [
+    {
+      id: "mon",
+      label: "月",
+    },
+    {
+      id: "tue",
+      label: "火",
+    },
+    {
+      id: "wed",
+      label: "水",
+    },
+    {
+      id: "thu",
+      label: "木",
+    },
+    {
+      id: "fri",
+      label: "金",
+    },
+    {
+      id: "sat",
+      label: "土",
+    },
+    {
+      id: "sun",
+      label: "日",
+    },
+  ];
+
+  return (
+    <Row>
+      {weekDays.map((weekDay) => {
+        return (
+          <Col key={weekDay.id} className="p-1">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                console.log(weekDay.id);
+              }}
+            >
+              {weekDay.label}
+            </Button>
+          </Col>
+        );
+      })}
+    </Row>
+  );
+};

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -41,9 +41,6 @@ export interface StatusInfo {
   busy: number;
   usersStatus: UsersStatus;
 }
-export type DateTimeToStatusInfoList = {
-  [dateTimeOrWeekDay in DateTimeOrWeekDay]?: StatusInfo | undefined;
-};
 
 export const storeDateStatusList = async (
   dateStatusList: DateStatusList,

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -4,9 +4,23 @@ import firebase from "firebase/app";
 
 export type Status = "calendar-free" | "calendar-busy";
 
-export type WeekDay = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+export type WeekDay = "sun" | "mon" | "tue" | "wed" | "thu" | "fri" | "sat";
 
 type DateTimeOrWeekDay = number | WeekDay;
+
+export const dateTimeToWeekDay = (dateTime: number): WeekDay => {
+  const date = new Date(dateTime);
+  const weekDayArray: WeekDay[] = [
+    "sun",
+    "mon",
+    "tue",
+    "wed",
+    "thu",
+    "fri",
+    "sat",
+  ];
+  return weekDayArray[date.getDay()];
+};
 
 // dateTime => Date: new Date(dateTime), Date => dateTime: Date.getTime()
 export type DateStatusList = {

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -4,15 +4,9 @@ import firebase from "firebase/app";
 
 export type Status = "calendar-free" | "calendar-busy";
 
-type DateTimeOrWeekDay =
-  | number
-  | "mon"
-  | "tue"
-  | "wed"
-  | "thu"
-  | "fri"
-  | "sat"
-  | "sun";
+export type WeekDay = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+type DateTimeOrWeekDay = number | WeekDay;
 
 // dateTime => Date: new Date(dateTime), Date => dateTime: Date.getTime()
 export type DateStatusList = {

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -4,10 +4,20 @@ import firebase from "firebase/app";
 
 export type Status = "calendar-free" | "calendar-busy";
 
+type DateTimeOrWeekDay =
+  | number
+  | "mon"
+  | "tue"
+  | "wed"
+  | "thu"
+  | "fri"
+  | "sat"
+  | "sun";
+
 // dateTime => Date: new Date(dateTime), Date => dateTime: Date.getTime()
-export interface DateStatusList {
-  [dateTime: number]: Status | undefined;
-}
+export type DateStatusList = {
+  [dateTimeOrWeekDay in DateTimeOrWeekDay]?: Status | undefined;
+};
 
 export interface UserDateStatusList {
   user: UserWithId;
@@ -23,9 +33,9 @@ export interface StatusInfo {
   busy: number;
   usersStatus: UsersStatus;
 }
-export interface DateTimeToStatusInfoList {
-  [dateTime: number]: StatusInfo | undefined;
-}
+export type DateTimeToStatusInfoList = {
+  [dateTimeOrWeekDay in DateTimeOrWeekDay]?: StatusInfo | undefined;
+};
 
 export const storeDateStatusList = async (
   dateStatusList: DateStatusList,
@@ -55,7 +65,7 @@ export const loadDateStatusList = async (
     const dateStatusList = snapShot.val() as DateStatusList;
     return dateStatusList;
   } else {
-    return [];
+    return {};
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/groups/[groupId]/index.tsx
+++ b/pages/groups/[groupId]/index.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from "next";
 import { Layout } from "../../../components/Layout";
 import { ErrorPage } from "../../../components/ErrorPage";
 import { GroupWithId, loadGroup } from "../../../interfaces/Group";
-import { useContext, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import { AuthContext } from "../../../context/AuthContext";
 import React from "react";
 import {
@@ -11,7 +11,7 @@ import {
 } from "../../../interfaces/DateStatus";
 import { GroupCalendar } from "../../../components/GroupCalendar";
 import { loadUser } from "../../../interfaces/User";
-import { Button, Row } from "react-bootstrap";
+import { Button, Overlay, Row, Tooltip } from "react-bootstrap";
 import Link from "next/link";
 import { MyHead } from "components/MyHead";
 
@@ -31,6 +31,8 @@ const GroupCalendarPage = ({
   const [groupDateStatusList, setGroupDateStatusList] = useState(
     initGroupDateStatusList
   );
+  const reloadButtonRef = useRef(null);
+  const [showTooltip, setShowTooltip] = useState(false);
 
   if (errors) {
     return <ErrorPage errorMessage={errors} />;
@@ -91,6 +93,7 @@ const GroupCalendarPage = ({
 
         setGroup(newGroup);
         setGroupDateStatusList(newGroupDateStatusList);
+        setShowTooltip(true);
       }
     } catch {
       console.error("Unexpected Error");
@@ -107,13 +110,28 @@ const GroupCalendarPage = ({
           </Row>
           <Row className="justify-content-center">
             <Button
+              ref={reloadButtonRef}
               className="m-2"
               variant="accent"
               type="button"
               onClick={reload}
+              onBlur={() => {
+                setShowTooltip(false);
+              }}
             >
               更新
             </Button>
+            <Overlay
+              target={reloadButtonRef.current}
+              show={showTooltip}
+              placement="right"
+            >
+              {(props) => (
+                <Tooltip id="update-group-tooltip" {...props}>
+                  更新しました！
+                </Tooltip>
+              )}
+            </Overlay>
           </Row>
           <Row className="justify-content-center">
             <GroupCalendar

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import { About } from "components/About";
 import { GroupList } from "components/GroupList";
 import { MyHead } from "components/MyHead";
+import { WeekDayButtons } from "components/WeekDayButtons";
 import { GroupWithId, loadGroup } from "interfaces/Group";
 import { loadUser, UserWithId } from "interfaces/User";
 import Link from "next/link";
@@ -131,6 +132,12 @@ const IndexPage = (): JSX.Element => {
             <p className="text-main">「忙しい」</p>
             <p className="text-muted">「未定」</p>
             <p className="text-muted">を切り替え</p>
+          </Row>
+          <Row className="justify-content-center">
+            <WeekDayButtons
+              dateStatusList={dateStatusList}
+              setDateStatusList={(list) => setDateStatusList(list)}
+            />
           </Row>
           <Row className="justify-content-center">
             <UserCalendar

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -127,7 +127,7 @@ const IndexPage = (): JSX.Element => {
             <h1>{user.name}</h1>
           </Row>
           <Row className="justify-content-center">
-            <p className="text-muted">日付をクリックして</p>
+            <p className="text-muted">日付，曜日ボタンをクリックして</p>
             <p className="text-accent">「暇」</p>
             <p className="text-main">「忙しい」</p>
             <p className="text-muted">「未定」</p>


### PR DESCRIPTION
# 概要

- UserCalendarに曜日ボタンを追加して曜日の状態を一括で変更できるようにした
- 日付の状態に指定があればそちらが優先される
- 曜日ではcaledar-freeだが特定の日付は未定という状態はできないようにした
  - できた方がいいかもしれない
- GroupCalendar更新時にツールチップをオーバーレイ表示するようにした

# 動作確認

![821643c76b33deaa4a5a267f306c0181](https://user-images.githubusercontent.com/43720583/125186651-9805f180-e266-11eb-8005-8629a399fc6d.png)