### PR TITLE
メールアドレスとパスワードでユーザー作成時に途中で失敗したらfirebase auth のUserを削除する

### DIFF
--- a/components/DeleteUserButton.tsx
+++ b/components/DeleteUserButton.tsx
@@ -19,15 +19,15 @@ export const DeleteUserButton = ({
     if (authUser == null) {
       console.error("Unexpected Error");
     } else {
-      Promise.all([authUser.delete(), deleteUser(user)])
-        .then(() => {
-          if (onDeleted != null) {
-            onDeleted();
-          }
-        })
-        .catch(() => {
-          console.error("Unexpected Error");
-        });
+      try {
+        await authUser.delete();
+        await deleteUser(user);
+        if (onDeleted != null) {
+          onDeleted();
+        }
+      } catch {
+        console.error("Unexpected Error");
+      }
     }
   };
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/utils/auth-provider.ts
+++ b/utils/auth-provider.ts
@@ -54,8 +54,8 @@ export const storeUserfromLoginResult = async (): Promise<void> => {
   } catch (error) {
     try {
       // ユーザ作成に失敗したらfirebase authのユーザーを削除
-      console.error(error);
       await authUser?.delete();
+      console.error(error);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
# 概要

- メールアドレスとパスワードでユーザーを作成するときに途中で失敗するとauthUserはあるがUserはない状態になってしまうのでその場合authUserを削除するようにした

- ユーザー削除も一応authUser削除を優先するようにした
  - 削除の際のauthUserとUserの同期は難しい

