### PR TITLE
日時表示の月を修正

### DIFF
--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -123,9 +123,9 @@ export const UserInfoOfDay = ({
     }
   };
 
-  const dateText = `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}(${dayFormat(
-    date.getDay()
-  )})`;
+  const dateText = `${date.getFullYear()}/${
+    date.getMonth() + 1
+  }/${date.getDate()}(${dayFormat(date.getDay())})`;
 
   const cardTitleText =
     statusInfo == null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
# 概要

- イベントメッセージなどの日時表示のうち月が1つ前にずれているのを修正
