### PR TITLE
データの取得をSSRではなくCSRで行う

### DIFF
--- a/components/AboutPage.tsx
+++ b/components/AboutPage.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import Image from "next/image";
 import { Button, Col, Row } from "react-bootstrap";
 import Router from "next/router";
+import { MyHead } from "./MyHead";
+import { Layout } from "./Layout";
 
-export const About = (): JSX.Element => {
+export const AboutPage = (): JSX.Element => {
   return (
-    <React.Fragment>
+    <Layout>
+      <MyHead title="Hima Share" />
       <Row className="hima-share-index mt-5">
         <Col md={6} className="text-center align-self-center">
           <h1>Hima Share(β)</h1>
@@ -73,6 +76,6 @@ export const About = (): JSX.Element => {
           ユーザー登録
         </Button>
       </Row>
-    </React.Fragment>
+    </Layout>
   );
 };

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Modal, Button } from "react-bootstrap";
 
-interface ConfirmModalProps {
+type ConfirmModalProps = {
   show: boolean;
   setShow: (show: boolean) => void;
   headerText: string;
   bodyText: string;
   confirmButtonText: string;
   onClickConfirmButton: () => void;
-}
+};
 
 export const ConfirmModal = ({
   show,

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -3,9 +3,8 @@ import { Form, Button } from "react-bootstrap";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Router from "next/router";
-import React, { useContext } from "react";
-import { AuthContext } from "../context/AuthContext";
 import { Group, storeGroup } from "../interfaces/Group";
+import firebase from "firebase/app";
 
 interface InputsType {
   name: string;
@@ -19,8 +18,13 @@ const schema = yup.object().shape({
   chatId: yup.string().max(20, "チャットIDは20文字までです"),
 });
 
-export const CreateGroupForm = (): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
+type CreateGroupFormProps = {
+  authUser: firebase.User;
+};
+
+export const CreateGroupForm = ({
+  authUser,
+}: CreateGroupFormProps): JSX.Element => {
   const {
     register,
     handleSubmit,
@@ -34,21 +38,17 @@ export const CreateGroupForm = (): JSX.Element => {
     });
   };
   const createGroup = async (data: InputsType) => {
-    if (authUser != null) {
-      const group: Group = {
-        name: data["name"],
-        description: data["description"],
-      };
-      storeGroup(group, authUser.uid, data["chatId"])
-        .then(() => {
-          Router.push("/");
-        })
-        .catch(() => {
-          setUnexpectedError();
-        });
-    } else {
-      setUnexpectedError();
-    }
+    const group: Group = {
+      name: data["name"],
+      description: data["description"],
+    };
+    storeGroup(group, authUser.uid, data["chatId"])
+      .then(() => {
+        Router.push("/");
+      })
+      .catch(() => {
+        setUnexpectedError();
+      });
   };
   return (
     <Form onSubmit={handleSubmit(createGroup)}>

--- a/components/CreateGroupForm.tsx
+++ b/components/CreateGroupForm.tsx
@@ -6,11 +6,11 @@ import Router from "next/router";
 import { Group, storeGroup } from "../interfaces/Group";
 import firebase from "firebase/app";
 
-interface InputsType {
+type InputsType = {
   name: string;
   description: string;
   chatId: string;
-}
+};
 
 const schema = yup.object().shape({
   name: yup.string().max(20, "名前は20文字までです").required("名前は必須です"),

--- a/components/CreateInvitationForm.tsx
+++ b/components/CreateInvitationForm.tsx
@@ -1,12 +1,12 @@
 import { Form, Button } from "react-bootstrap";
 import Router from "next/router";
-import React, { useContext } from "react";
-import { AuthContext } from "../context/AuthContext";
 import { GroupWithId } from "../interfaces/Group";
 import { Invitation, storeInvitation } from "../interfaces/Invitation";
 import { useForm } from "react-hook-form";
+import firebase from "firebase/app";
 
 type Props = {
+  authUser: firebase.User;
   group: GroupWithId;
 };
 
@@ -15,8 +15,10 @@ type InputsType = {
   empty: undefined;
 };
 
-export const CreateInvitationForm = ({ group }: Props): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
+export const CreateInvitationForm = ({
+  authUser,
+  group,
+}: Props): JSX.Element => {
   const {
     handleSubmit,
     formState: { errors },

--- a/components/DeleteUserButton.tsx
+++ b/components/DeleteUserButton.tsx
@@ -4,11 +4,11 @@ import { Button } from "react-bootstrap";
 import { ConfirmModal } from "./ConfirmModal";
 import firebase from "firebase/app";
 
-interface DeleteUserButtonProps {
+type DeleteUserButtonProps = {
   authUser: firebase.User;
   user: UserWithId;
   onDeleted?: () => void;
-}
+};
 
 export const DeleteUserButton = ({
   authUser,

--- a/components/DeleteUserButton.tsx
+++ b/components/DeleteUserButton.tsx
@@ -1,33 +1,30 @@
-import { AuthContext } from "context/AuthContext";
 import { deleteUser, UserWithId } from "interfaces/User";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "react-bootstrap";
 import { ConfirmModal } from "./ConfirmModal";
+import firebase from "firebase/app";
 
 interface DeleteUserButtonProps {
+  authUser: firebase.User;
   user: UserWithId;
   onDeleted?: () => void;
 }
 
 export const DeleteUserButton = ({
+  authUser,
   user,
   onDeleted,
 }: DeleteUserButtonProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
   const [showModal, setShowModal] = useState(false);
   const onClickDeleteButton = async () => {
-    if (authUser == null) {
-      console.error("Unexpected Error");
-    } else {
-      try {
-        await authUser.delete();
-        await deleteUser(user);
-        if (onDeleted != null) {
-          onDeleted();
-        }
-      } catch {
-        console.error("Unexpected Error");
+    try {
+      await authUser.delete();
+      await deleteUser(user);
+      if (onDeleted != null) {
+        onDeleted();
       }
+    } catch {
+      console.error("Unexpected Error");
     }
   };
   return (

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,13 +1,13 @@
 import { Layout } from "./Layout";
 import { MyHead } from "./MyHead";
 
-type Props = {
+type ErrorPageProps = {
   errorMessage?: string;
 };
 
 export const ErrorPage = ({
   errorMessage = "Unexpected Error",
-}: Props): JSX.Element => {
+}: ErrorPageProps): JSX.Element => {
   return (
     <Layout>
       <MyHead title="エラー" />

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import { Layout } from "./Layout";
 import { MyHead } from "./MyHead";
+import { Row } from "react-bootstrap";
 
 type ErrorPageProps = {
   errorMessage?: string;
@@ -11,9 +12,11 @@ export const ErrorPage = ({
   return (
     <Layout>
       <MyHead title="エラー" />
-      <p>
-        <span style={{ color: "red" }}>Error:</span> {errorMessage}
-      </p>
+      <Row className="justify-content-center mt-3">
+        <p>
+          <span style={{ color: "red" }}>Error:</span> {errorMessage}
+        </p>
+      </Row>
     </Layout>
   );
 };

--- a/components/EventMessage.tsx
+++ b/components/EventMessage.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useRef } from "react";
 import { Button, Form, Overlay, Tooltip } from "react-bootstrap";
 
-interface EventMessageProps {
+type EventMessageProps = {
   dateText: string;
   freeChatIds: string[];
   unEnteredChatIds: string[];
   invitationId?: string;
-}
+};
 
 export const EventMessage = ({
   dateText,

--- a/components/GroupCalendar.tsx
+++ b/components/GroupCalendar.tsx
@@ -7,10 +7,10 @@ import {
 } from "../interfaces/DateStatus";
 import { UserInfoOfDay } from "./UserInfoOfDay";
 
-interface GroupCalendarProps {
+type GroupCalendarProps = {
   groupDateStatusList: UserDateStatusList[];
   group: GroupWithId;
-}
+};
 
 export const GroupCalendar = ({
   groupDateStatusList,

--- a/components/GroupList.tsx
+++ b/components/GroupList.tsx
@@ -2,9 +2,9 @@ import { GroupWithId } from "interfaces/Group";
 import Link from "next/link";
 import { ListGroup } from "react-bootstrap";
 
-interface GroupListProps {
+type GroupListProps = {
   groups: GroupWithId[];
-}
+};
 
 export const GroupList = ({ groups }: GroupListProps): JSX.Element => {
   const itemsComponent = groups.map((group) => (

--- a/components/GroupListForm.tsx
+++ b/components/GroupListForm.tsx
@@ -3,11 +3,11 @@ import { UserWithId } from "interfaces/User";
 import { Table } from "react-bootstrap";
 import { GroupListItem } from "./GrupListItem";
 
-interface GroupListFormProps {
+type GroupListFormProps = {
   user: UserWithId;
   groups: GroupWithId[];
   setGroups: (groups: GroupWithId[]) => void;
-}
+};
 
 export const GroupListForm = ({
   user,

--- a/components/GrupListItem.tsx
+++ b/components/GrupListItem.tsx
@@ -1,8 +1,7 @@
-import { AuthContext } from "context/AuthContext";
 import { GroupWithId } from "interfaces/Group";
 import { UserWithId, updateGroupChatId, leaveGroup } from "interfaces/User";
 import Link from "next/link";
-import React, { useContext, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Button, Col, Form, Overlay, Tooltip } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { ConfirmModal } from "./ConfirmModal";
@@ -24,7 +23,6 @@ export const GroupListItem = ({
   groups,
   setGroups,
 }: GroupListItemProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
   const initChatId = user.groups == null ? "" : user.groups[group.id];
   const updateButtonRef = useRef(null);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -45,33 +43,25 @@ export const GroupListItem = ({
   };
 
   const updateChatId = async (data: InputsType) => {
-    if (authUser == null) {
-      setUnexpectedError();
-    } else {
-      updateGroupChatId(user.id, group.id, data["chatId"])
-        .then(() => {
-          setShowTooltip(true);
-        })
-        .catch(() => {
-          setUnexpectedError();
-        });
-    }
+    updateGroupChatId(user.id, group.id, data["chatId"])
+      .then(() => {
+        setShowTooltip(true);
+      })
+      .catch(() => {
+        setUnexpectedError();
+      });
   };
 
   const onClickLeaveButton = async () => {
-    if (authUser == null) {
-      setShowModal(false);
-    } else {
-      setShowModal(false);
-      leaveGroup(user.id, group)
-        .then(() => {
-          const newGroups = groups.filter((g) => g.id !== group.id);
-          setGroups(newGroups);
-        })
-        .catch(() => {
-          console.error("Unexpected Error");
-        });
-    }
+    setShowModal(false);
+    leaveGroup(user.id, group)
+      .then(() => {
+        const newGroups = groups.filter((g) => g.id !== group.id);
+        setGroups(newGroups);
+      })
+      .catch(() => {
+        console.error("Unexpected Error");
+      });
   };
   return (
     <tr key={group.id}>

--- a/components/GrupListItem.tsx
+++ b/components/GrupListItem.tsx
@@ -6,16 +6,16 @@ import { Button, Col, Form, Overlay, Tooltip } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { ConfirmModal } from "./ConfirmModal";
 
-interface GroupListItemProps {
+type GroupListItemProps = {
   group: GroupWithId;
   user: UserWithId;
   groups: GroupWithId[];
   setGroups: (groups: GroupWithId[]) => void;
-}
+};
 
-interface InputsType {
+type InputsType = {
   chatId: string;
-}
+};
 
 export const GroupListItem = ({
   group,

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -12,15 +12,15 @@ import Link from "next/link";
 import { GoogleLoginButton } from "./GoogleLoginButton";
 import firebase from "firebase/app";
 
-interface JoinGroupFormProps {
+type JoinGroupFormProps = {
   authUser: firebase.User | null;
   user: UserWithId | null | undefined;
   group: GroupWithId;
-}
+};
 
-interface InputsType {
+type InputsType = {
   chatId: string;
-}
+};
 
 const schema = yup.object().shape({
   chatId: yup.string().max(20, "チャットIDは20文字までです"),

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -101,7 +101,7 @@ export const JoinGroupForm = ({
           </Row>
           {loginOrRegister == "login" && (
             <Row className="justify-content-center">
-              <LoginForm />
+              <LoginForm authUser={authUser} />
             </Row>
           )}
           {loginOrRegister == "register" && (

--- a/components/JoinGroupForm.tsx
+++ b/components/JoinGroupForm.tsx
@@ -24,8 +24,6 @@ const schema = yup.object().shape({
   chatId: yup.string().max(20, "チャットIDは20文字までです"),
 });
 
-type LoginOrRegister = "login" | "register";
-
 export const JoinGroupForm = ({ group }: JoinGroupFormProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);
   const [isAlreadyJoined, setIsAlreadyJoined] = useState<boolean | undefined>(
@@ -33,8 +31,9 @@ export const JoinGroupForm = ({ group }: JoinGroupFormProps): JSX.Element => {
   );
   const [user, setUser] = useState<UserWithId | undefined>(undefined);
 
-  const [loginOrRegister, setLoginOrRegister] =
-    useState<LoginOrRegister>("login");
+  const [loginOrRegister, setLoginOrRegister] = useState<"login" | "register">(
+    "login"
+  );
 
   // TODO よく使う処理なのでカスタムフックにする
   useEffect(() => {
@@ -116,19 +115,14 @@ export const JoinGroupForm = ({ group }: JoinGroupFormProps): JSX.Element => {
                 type={"radio"}
                 name="loginOrRegister"
                 label="ログイン"
-                onClick={() => {
-                  setLoginOrRegister("login");
-                }}
-                checked={loginOrRegister == "login"}
+                onChange={() => setLoginOrRegister("login")}
+                defaultChecked
               />
               <Form.Check
                 type={"radio"}
                 name="loginOrRegister"
                 label="登録"
-                onClick={() => {
-                  setLoginOrRegister("register");
-                }}
-                checked={loginOrRegister == "register"}
+                onChange={() => setLoginOrRegister("register")}
               />
             </Form>
           </Row>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -8,10 +8,11 @@ import Router from "next/router";
 import Image from "next/image";
 
 type LayoutProps = {
+  footerHide?: boolean;
   children?: ReactNode;
 };
 
-export const Layout = ({ children }: LayoutProps): JSX.Element => {
+export const Layout = ({ footerHide, children }: LayoutProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);
 
   const logout = async (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
@@ -53,45 +54,47 @@ export const Layout = ({ children }: LayoutProps): JSX.Element => {
         </Navbar>
       </header>
       <Container>{children}</Container>
-      <footer className="footer mt-auto py-3">
-        <hr />
-        <Container>
-          <Row className="justify-content-center">
-            <Link href="/">
-              <a>
-                <Image
-                  src="/logo.png"
-                  alt="Logo of Hima Share"
-                  width={200}
-                  height={25}
-                />
-              </a>
-            </Link>
-          </Row>
-          <Row className="justify-content-center">
-            <ListGroup horizontal={"md"}>
-              <ListGroup.Item className="border-0">
-                <Link href="/">
-                  <a className="text-muted">トップページ</a>
-                </Link>
-              </ListGroup.Item>
-              <ListGroup.Item className="border-0">
-                <Link href="/privacy-policy">
-                  <a className="text-muted">プライバシーポリシー</a>
-                </Link>
-              </ListGroup.Item>
-              <ListGroup.Item className="border-0">
-                <a
-                  className="text-muted"
-                  href="https://github.com/bana118/hima-share"
-                >
-                  Github
+      {!footerHide && (
+        <footer className="footer mt-auto py-3">
+          <hr />
+          <Container>
+            <Row className="justify-content-center">
+              <Link href="/">
+                <a>
+                  <Image
+                    src="/logo.png"
+                    alt="Logo of Hima Share"
+                    width={200}
+                    height={25}
+                  />
                 </a>
-              </ListGroup.Item>
-            </ListGroup>
-          </Row>
-        </Container>
-      </footer>
+              </Link>
+            </Row>
+            <Row className="justify-content-center">
+              <ListGroup horizontal={"md"}>
+                <ListGroup.Item className="border-0">
+                  <Link href="/">
+                    <a className="text-muted">トップページ</a>
+                  </Link>
+                </ListGroup.Item>
+                <ListGroup.Item className="border-0">
+                  <Link href="/privacy-policy">
+                    <a className="text-muted">プライバシーポリシー</a>
+                  </Link>
+                </ListGroup.Item>
+                <ListGroup.Item className="border-0">
+                  <a
+                    className="text-muted"
+                    href="https://github.com/bana118/hima-share"
+                  >
+                    Github
+                  </a>
+                </ListGroup.Item>
+              </ListGroup>
+            </Row>
+          </Container>
+        </footer>
+      )}
     </div>
   );
 };

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,9 +7,9 @@ import { Navbar, Nav, Container, Row, ListGroup } from "react-bootstrap";
 import Router from "next/router";
 import Image from "next/image";
 
-interface LayoutProps {
+type LayoutProps = {
   children?: ReactNode;
-}
+};
 
 export const Layout = ({ children }: LayoutProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);

--- a/components/LoadingPage.tsx
+++ b/components/LoadingPage.tsx
@@ -1,0 +1,14 @@
+import { Row, Spinner } from "react-bootstrap";
+import { Layout } from "./Layout";
+import { MyHead } from "./MyHead";
+
+export const LoaingPage = (): JSX.Element => {
+  return (
+    <Layout>
+      <MyHead title="ローディング中" />
+      <Row className="justify-content-center">
+        <Spinner animation="border" />
+      </Row>
+    </Layout>
+  );
+};

--- a/components/LoadingPage.tsx
+++ b/components/LoadingPage.tsx
@@ -1,14 +1,12 @@
-import { Row, Spinner } from "react-bootstrap";
+import { Row } from "react-bootstrap";
 import { Layout } from "./Layout";
 import { MyHead } from "./MyHead";
 
 export const LoaingPage = (): JSX.Element => {
   return (
-    <Layout>
+    <Layout footerHide>
       <MyHead title="ローディング中" />
-      <Row className="justify-content-center">
-        <Spinner animation="border" />
-      </Row>
+      <Row className="justify-content-center" />
     </Layout>
   );
 };

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,8 +1,6 @@
 import { useForm } from "react-hook-form";
 import { Form, Button } from "react-bootstrap";
 import { auth } from "../utils/firebase";
-import { AuthContext } from "context/AuthContext";
-import { useContext } from "react";
 import firebase from "firebase/app";
 
 type InputsType = {
@@ -11,17 +9,20 @@ type InputsType = {
 };
 
 type LoginFormProps = {
+  authUser: firebase.User | null;
   onLogined?: () => void;
 };
 
-export const LoginForm = ({ onLogined }: LoginFormProps): JSX.Element => {
+export const LoginForm = ({
+  authUser,
+  onLogined,
+}: LoginFormProps): JSX.Element => {
   const {
     register,
     handleSubmit,
     setError,
     formState: { errors },
   } = useForm<InputsType>();
-  const { authUser } = useContext(AuthContext);
 
   const login = async (data: InputsType) => {
     auth
@@ -80,7 +81,7 @@ export const LoginForm = ({ onLogined }: LoginFormProps): JSX.Element => {
       } catch {
         console.error("Unexpected Error");
       }
-    } else if (authUser != null) {
+    } else {
       try {
         await updateCredential(data);
       } catch {

--- a/components/MyHead.tsx
+++ b/components/MyHead.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
 
-interface MyHeadProps {
+type MyHeadProps = {
   title?: string;
-}
+};
 
 export const MyHead = ({
   title = "Default Title",

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -6,17 +6,17 @@ import { auth } from "../utils/firebase";
 import { storeUser, User } from "../interfaces/User";
 import firebase from "firebase/app";
 
-interface RegisterFormProps {
+type RegisterFormProps = {
   onRegistered?: () => void;
-}
+};
 
-interface InputsType {
+type InputsType = {
   email: string;
   name: string;
   description: string;
   password: string;
   confirmPassword: string;
-}
+};
 
 const schema = yup.object().shape({
   email: yup

--- a/components/SendResetPasswordMailForm.tsx
+++ b/components/SendResetPasswordMailForm.tsx
@@ -3,8 +3,7 @@ import { Form, Button, Overlay, Tooltip } from "react-bootstrap";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { auth } from "../utils/firebase";
-import React, { useContext, useRef, useState } from "react";
-import { AuthContext } from "context/AuthContext";
+import { useRef, useState } from "react";
 
 interface InputsType {
   email: string;
@@ -19,7 +18,6 @@ const schema = yup.object().shape({
 });
 
 export const SendResetPasswordMailForm = (): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
   const buttonRef = useRef(null);
   const [showTooltip, setShowTooltip] = useState(false);
   const {
@@ -36,15 +34,11 @@ export const SendResetPasswordMailForm = (): JSX.Element => {
   };
 
   const sendResetMail = async (data: InputsType) => {
-    if (authUser != null) {
+    try {
+      await auth.sendPasswordResetEmail(data["email"]);
+      setShowTooltip(true);
+    } catch {
       setUnexpectedError();
-    } else {
-      try {
-        await auth.sendPasswordResetEmail(data["email"]);
-        setShowTooltip(true);
-      } catch {
-        setUnexpectedError();
-      }
     }
   };
   // TODO エラーメッセージがなぜかでない？

--- a/components/SendResetPasswordMailForm.tsx
+++ b/components/SendResetPasswordMailForm.tsx
@@ -5,9 +5,9 @@ import * as yup from "yup";
 import { auth } from "../utils/firebase";
 import { useRef, useState } from "react";
 
-interface InputsType {
+type InputsType = {
   email: string;
-}
+};
 
 const schema = yup.object().shape({
   email: yup

--- a/components/UpdateEmailForm.tsx
+++ b/components/UpdateEmailForm.tsx
@@ -4,12 +4,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { auth } from "../utils/firebase";
 import firebase from "firebase/app";
-import { useContext } from "react";
-import { AuthContext } from "context/AuthContext";
-
-interface UpdateEmailFormProps {
-  onUpdated?: (newEmail: string) => void;
-}
 
 interface InputsType {
   email: string;
@@ -50,10 +44,15 @@ const schema = yup.object().shape({
     ),
 });
 
+type UpdateEmailFormProps = {
+  authUser: firebase.User;
+  onUpdated?: (newEmail: string) => void;
+};
+
 export const UpdateEmailForm = ({
+  authUser,
   onUpdated,
 }: UpdateEmailFormProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
   const {
     register,
     handleSubmit,
@@ -68,20 +67,16 @@ export const UpdateEmailForm = ({
   };
 
   const updateEmail = async (data: InputsType) => {
-    if (authUser == null) {
-      setUnexpectedError();
-    } else {
-      try {
-        await authUser.updateEmail(data["email"]);
-        await authUser.sendEmailVerification({
-          url: `${document.location.origin}`,
-        });
-        if (onUpdated != null) {
-          onUpdated(data["email"]);
-        }
-      } catch {
-        setUnexpectedError();
+    try {
+      await authUser.updateEmail(data["email"]);
+      await authUser.sendEmailVerification({
+        url: `${document.location.origin}`,
+      });
+      if (onUpdated != null) {
+        onUpdated(data["email"]);
       }
+    } catch {
+      setUnexpectedError();
     }
   };
   // TODO エラーメッセージがなぜかでない？

--- a/components/UpdateEmailForm.tsx
+++ b/components/UpdateEmailForm.tsx
@@ -5,9 +5,9 @@ import * as yup from "yup";
 import { auth } from "../utils/firebase";
 import firebase from "firebase/app";
 
-interface InputsType {
+type InputsType = {
   email: string;
-}
+};
 
 const schema = yup.object().shape({
   email: yup

--- a/components/UpdateGroupForm.tsx
+++ b/components/UpdateGroupForm.tsx
@@ -10,10 +10,10 @@ type UpdateGroupFormProps = {
   defaultValues: InputsType;
 };
 
-interface InputsType {
+type InputsType = {
   name: string;
   description: string;
-}
+};
 
 const schema = yup.object().shape({
   name: yup.string().max(20, "名前は20文字までです").required("名前は必須です"),

--- a/components/UpdateGroupForm.tsx
+++ b/components/UpdateGroupForm.tsx
@@ -2,14 +2,13 @@ import { useForm } from "react-hook-form";
 import { Form, Button, Overlay, Tooltip } from "react-bootstrap";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
-import { useContext, useRef, useState } from "react";
-import { AuthContext } from "context/AuthContext";
+import { useRef, useState } from "react";
 import { GroupWithId, updateGroup } from "interfaces/Group";
 
-interface UpdateGroupFormProps {
+type UpdateGroupFormProps = {
   group: GroupWithId;
   defaultValues: InputsType;
-}
+};
 
 interface InputsType {
   name: string;
@@ -25,8 +24,6 @@ export const UpdateGroupForm = ({
   group,
   defaultValues,
 }: UpdateGroupFormProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
-
   const {
     register,
     handleSubmit,
@@ -47,17 +44,13 @@ export const UpdateGroupForm = ({
   const [showTooltip, setShowTooltip] = useState(false);
 
   const onSubmit = async (data: InputsType) => {
-    if (authUser == null) {
-      setUnexpectedError();
-    } else {
-      updateGroup(group, data["name"], data["description"])
-        .then(() => {
-          setShowTooltip(true);
-        })
-        .catch(() => {
-          setUnexpectedError();
-        });
-    }
+    updateGroup(group, data["name"], data["description"])
+      .then(() => {
+        setShowTooltip(true);
+      })
+      .catch(() => {
+        setUnexpectedError();
+      });
   };
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>

--- a/components/UpdatePasswordForm.tsx
+++ b/components/UpdatePasswordForm.tsx
@@ -2,14 +2,8 @@ import { useForm } from "react-hook-form";
 import { Form, Button } from "react-bootstrap";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
-import { useContext } from "react";
-import { AuthContext } from "context/AuthContext";
 import { getProviderUserData } from "utils/auth-provider";
 import firebase from "firebase/app";
-
-interface UpdatePasswordFormProps {
-  onUpdated?: () => void;
-}
 
 interface InputsType {
   password: string;
@@ -31,10 +25,15 @@ const schema = yup.object().shape({
     .required("パスワードは必須です"),
 });
 
+type UpdatePasswordFormProps = {
+  authUser: firebase.User;
+  onUpdated?: () => void;
+};
+
 export const UpdatePasswordForm = ({
+  authUser,
   onUpdated,
 }: UpdatePasswordFormProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
   const {
     register,
     handleSubmit,
@@ -48,10 +47,6 @@ export const UpdatePasswordForm = ({
     });
   };
   const updatePassword = async (data: InputsType) => {
-    if (authUser == null) {
-      setUnexpectedError();
-      return;
-    }
     const passwordUserData = getProviderUserData(authUser, "password");
     if (passwordUserData == null) {
       // パスワードの追加

--- a/components/UpdatePasswordForm.tsx
+++ b/components/UpdatePasswordForm.tsx
@@ -5,10 +5,10 @@ import * as yup from "yup";
 import { getProviderUserData } from "utils/auth-provider";
 import firebase from "firebase/app";
 
-interface InputsType {
+type InputsType = {
   password: string;
   confirmPassword: string;
-}
+};
 
 const schema = yup.object().shape({
   password: yup

--- a/components/UpdateUserForm.tsx
+++ b/components/UpdateUserForm.tsx
@@ -3,13 +3,8 @@ import { Form, Button, Overlay, Tooltip } from "react-bootstrap";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { updateUser, UserWithId } from "interfaces/User";
-import { useContext, useRef, useState } from "react";
-import { AuthContext } from "context/AuthContext";
-
-interface UpdateUserFormProps {
-  user: UserWithId;
-  defaultValues: InputsType;
-}
+import { useRef, useState } from "react";
+import firebase from "firebase/app";
 
 interface InputsType {
   name: string;
@@ -21,12 +16,17 @@ const schema = yup.object().shape({
   description: yup.string().max(100, "プロフィールは100文字までです"),
 });
 
+type UpdateUserFormProps = {
+  authUser: firebase.User;
+  user: UserWithId;
+  defaultValues: InputsType;
+};
+
 export const UpdateUserForm = ({
+  authUser,
   user,
   defaultValues,
 }: UpdateUserFormProps): JSX.Element => {
-  const { authUser } = useContext(AuthContext);
-
   const {
     register,
     handleSubmit,
@@ -47,23 +47,20 @@ export const UpdateUserForm = ({
   const [showTooltip, setShowTooltip] = useState(false);
 
   const onSubmit = async (data: InputsType) => {
-    if (authUser == null) {
-      setUnexpectedError();
-    } else {
-      Promise.all([
-        authUser.updateProfile({
-          displayName: data["name"],
-        }),
-        updateUser(user, data["name"], data["description"]),
-      ])
-        .then(() => {
-          setShowTooltip(true);
-        })
-        .catch(() => {
-          setUnexpectedError();
-        });
-    }
+    Promise.all([
+      authUser.updateProfile({
+        displayName: data["name"],
+      }),
+      updateUser(user, data["name"], data["description"]),
+    ])
+      .then(() => {
+        setShowTooltip(true);
+      })
+      .catch(() => {
+        setUnexpectedError();
+      });
   };
+
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <Form.Group>

--- a/components/UpdateUserForm.tsx
+++ b/components/UpdateUserForm.tsx
@@ -6,10 +6,10 @@ import { updateUser, UserWithId } from "interfaces/User";
 import { useRef, useState } from "react";
 import firebase from "firebase/app";
 
-interface InputsType {
+type InputsType = {
   name: string;
   description: string;
-}
+};
 
 const schema = yup.object().shape({
   name: yup.string().max(20, "名前は20文字までです").required("名前は必須です"),

--- a/components/UserInfoOfDay.tsx
+++ b/components/UserInfoOfDay.tsx
@@ -7,13 +7,13 @@ import React from "react";
 import { Button, Card, Table } from "react-bootstrap";
 import { EventMessage } from "./EventMessage";
 
-interface UserInfoOfDayProps {
+type UserInfoOfDayProps = {
   date: Date | null;
   groupId: string;
   invitationId?: string;
   groupDateStatusList: UserDateStatusList[];
   close: () => void;
-}
+};
 
 export const UserInfoOfDay = ({
   date,

--- a/components/WeekDayButtons.tsx
+++ b/components/WeekDayButtons.tsx
@@ -1,10 +1,10 @@
 import { Button, Col, Row } from "react-bootstrap";
 import { DateStatusList, WeekDay } from "../interfaces/DateStatus";
 
-interface WeekDayButtonsProps {
+type WeekDayButtonsProps = {
   dateStatusList: DateStatusList;
   setDateStatusList: (list: DateStatusList) => void;
-}
+};
 
 export const WeekDayButtons = ({
   dateStatusList,

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from "react";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AsyncFunction<T> = (props: any) => Promise<T>;
+
+export const useAsync = <T>(
+  asyncFunction: AsyncFunction<T>,
+  functionProps: unknown
+): {
+  data: T | null | undefined;
+  error: string | null;
+  isLoading: boolean;
+} => {
+  const [data, setData] = useState<T | undefined | null>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  useEffect(() => {
+    let unmounted = false;
+    const setDataFromAsyncFunction = async () => {
+      try {
+        console.log(functionProps);
+        const loadedData = await asyncFunction(functionProps);
+        if (!unmounted) {
+          setData(loadedData);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!unmounted) {
+          setError(error);
+          setData(null);
+        }
+      } finally {
+        if (!unmounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+    setDataFromAsyncFunction();
+    const cleanup = () => {
+      unmounted = true;
+    };
+    return cleanup;
+  }, [asyncFunction, functionProps]);
+  return { data, error, isLoading };
+};

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -5,20 +5,20 @@ type AsyncFunction<T> = (props: any) => Promise<T>;
 
 export const useAsync = <T>(
   asyncFunction: AsyncFunction<T>,
-  functionProps: unknown
+  functionProps: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  propsTypeGuard?: (arg: any) => boolean
 ): {
   data: T | null | undefined;
   error: string | null;
-  isLoading: boolean;
 } => {
   const [data, setData] = useState<T | undefined | null>(undefined);
   const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
   useEffect(() => {
     let unmounted = false;
     const setDataFromAsyncFunction = async () => {
+      if (propsTypeGuard != null && !propsTypeGuard(functionProps)) return;
       try {
-        console.log(functionProps);
         const loadedData = await asyncFunction(functionProps);
         if (!unmounted) {
           setData(loadedData);
@@ -29,10 +29,6 @@ export const useAsync = <T>(
           setError(error);
           setData(null);
         }
-      } finally {
-        if (!unmounted) {
-          setIsLoading(false);
-        }
       }
     };
     setDataFromAsyncFunction();
@@ -40,6 +36,6 @@ export const useAsync = <T>(
       unmounted = true;
     };
     return cleanup;
-  }, [asyncFunction, functionProps]);
-  return { data, error, isLoading };
+  }, [asyncFunction, functionProps, propsTypeGuard]);
+  return { data, error };
 };

--- a/interfaces/DateStatus.ts
+++ b/interfaces/DateStatus.ts
@@ -27,20 +27,20 @@ export type DateStatusList = {
   [dateTimeOrWeekDay in DateTimeOrWeekDay]?: Status | undefined;
 };
 
-export interface UserDateStatusList {
+export type UserDateStatusList = {
   user: UserWithId;
   dateStatusList: DateStatusList;
-}
+};
 
-export interface UsersStatus {
+export type UsersStatus = {
   [uid: string]: Status | undefined;
-}
+};
 
-export interface StatusInfo {
+export type StatusInfo = {
   free: number;
   busy: number;
   usersStatus: UsersStatus;
-}
+};
 
 export const storeDateStatusList = async (
   dateStatusList: DateStatusList,

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -96,6 +96,7 @@ export const loadGroupAndGroupDateStatusList = async (
 } | null> => {
   const group = await loadGroup(groupId);
   if (group == null || group.members == null) return null;
+
   const userIds = Object.keys(group.members);
   const nullableGroupDateStatusList = await Promise.all(
     userIds.map(async (userId) => {

--- a/interfaces/Group.ts
+++ b/interfaces/Group.ts
@@ -1,6 +1,7 @@
 import { db } from "../utils/firebase";
-import { joinGroup } from "./User";
+import { joinGroup, loadUser } from "./User";
 import firebase from "firebase/app";
+import { loadDateStatusList, UserDateStatusList } from "./DateStatus";
 
 export interface Group {
   name: string;
@@ -85,6 +86,51 @@ export const setInvitation = async (
 ): Promise<string> => {
   await db.ref(`groups/${groupId}`).update({ invitationId: invitationId });
   return invitationId;
+};
+
+export const loadGroupAndGroupDateStatusList = async (
+  groupId: string
+): Promise<{
+  group: GroupWithId;
+  groupDateStatusList: UserDateStatusList[];
+} | null> => {
+  const group = await loadGroup(groupId);
+  if (group == null || group.members == null) return null;
+  const userIds = Object.keys(group.members);
+  const nullableGroupDateStatusList = await Promise.all(
+    userIds.map(async (userId) => {
+      return {
+        user: await loadUser(userId),
+        dateStatusList: await loadDateStatusList(userId),
+      };
+    })
+  );
+  const groupDateStatusList: UserDateStatusList[] = [];
+  for (let i = 0; i < userIds.length; i++) {
+    const user = nullableGroupDateStatusList[i].user;
+    const dateStatusList = nullableGroupDateStatusList[i].dateStatusList;
+    if (user == null) {
+      return null;
+    }
+    groupDateStatusList.push({
+      user: user,
+      dateStatusList: dateStatusList,
+    });
+  }
+
+  groupDateStatusList.sort((a, b) => {
+    const nameA = a.user.name.toUpperCase();
+    const nameB = b.user.name.toUpperCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  return { group, groupDateStatusList };
 };
 
 export const watchGroup = (

--- a/interfaces/Invitation.ts
+++ b/interfaces/Invitation.ts
@@ -40,12 +40,14 @@ export const loadInvitation = async (
   }
 };
 
-export const loadInvitationGroup = async (
+export const loadInvitationAndGroup = async (
   invitationId: string
-): Promise<GroupWithId | null> => {
+): Promise<{ invitation: InvitationWithId; group: GroupWithId } | null> => {
   const invitation = await loadInvitation(invitationId);
   if (invitation == null) return null;
-  return await loadGroup(invitation.groupId);
+  const group = await loadGroup(invitation.groupId);
+  if (group == null) return null;
+  return { invitation, group };
 };
 
 export const deleteInvitation = async (

--- a/interfaces/Invitation.ts
+++ b/interfaces/Invitation.ts
@@ -1,5 +1,5 @@
 import { db } from "../utils/firebase";
-import { setInvitation } from "./Group";
+import { GroupWithId, loadGroup, setInvitation } from "./Group";
 
 export interface Invitation {
   groupId: string;
@@ -38,6 +38,14 @@ export const loadInvitation = async (
   } else {
     return null;
   }
+};
+
+export const loadInvitationGroup = async (
+  invitationId: string
+): Promise<GroupWithId | null> => {
+  const invitation = await loadInvitation(invitationId);
+  if (invitation == null) return null;
+  return await loadGroup(invitation.groupId);
 };
 
 export const deleteInvitation = async (

--- a/interfaces/User.ts
+++ b/interfaces/User.ts
@@ -28,6 +28,37 @@ export const loadUser = async (uid: string): Promise<UserWithId | null> => {
   }
 };
 
+export const loadUserAndGroups = async (
+  uid: string
+): Promise<{ user: UserWithId; groups: GroupWithId[] } | null> => {
+  const user = await loadUser(uid);
+  if (user == null) return null;
+  const groups: GroupWithId[] = [];
+
+  if (user.groups == null) return { user, groups };
+
+  const groupIds = Object.keys(user.groups);
+  const nullableGroups = await Promise.all(
+    groupIds.map((groupId) => loadGroup(groupId))
+  );
+  for (const nullableGroup of nullableGroups) {
+    if (nullableGroup == null) return null;
+    groups.push(nullableGroup);
+  }
+  groups.sort((a, b) => {
+    const nameA = a.name.toUpperCase();
+    const nameB = b.name.toUpperCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  });
+  return { user, groups };
+};
+
 export const joinGroup = async (
   uid: string,
   groupId: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hima-share",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 
 const CreateGroupPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
+
   useEffect(() => {
     if (authUser === null) {
       Router.push("/login");
@@ -17,6 +18,7 @@ const CreateGroupPage = (): JSX.Element => {
       Router.push("/email-verify");
     }
   }, [authUser]);
+
   return (
     <Layout>
       {authUser && !(authUser != null && !authUser.emailVerified) && (

--- a/pages/create-group.tsx
+++ b/pages/create-group.tsx
@@ -7,6 +7,7 @@ import Router from "next/router";
 import { MyHead } from "components/MyHead";
 import { Row } from "react-bootstrap";
 import Link from "next/link";
+import { LoaingPage } from "components/LoadingPage";
 
 const CreateGroupPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
@@ -19,24 +20,26 @@ const CreateGroupPage = (): JSX.Element => {
     }
   }, [authUser]);
 
+  if (authUser == null || (authUser != null && !authUser.emailVerified)) {
+    return <LoaingPage />;
+  }
+
   return (
     <Layout>
-      {authUser && !(authUser != null && !authUser.emailVerified) && (
-        <React.Fragment>
-          <MyHead title="グループ作成" />
-          <Row className="justify-content-center">
-            <h1>グループ作成</h1>
-          </Row>
-          <Row className="justify-content-center">
-            <CreateGroupForm />
-          </Row>
-          <Row className="justify-content-center">
-            <Link href="/">
-              <a>戻る</a>
-            </Link>
-          </Row>
-        </React.Fragment>
-      )}
+      <React.Fragment>
+        <MyHead title="グループ作成" />
+        <Row className="justify-content-center">
+          <h1>グループ作成</h1>
+        </Row>
+        <Row className="justify-content-center">
+          <CreateGroupForm authUser={authUser} />
+        </Row>
+        <Row className="justify-content-center">
+          <Link href="/">
+            <a>戻る</a>
+          </Link>
+        </Row>
+      </React.Fragment>
     </Layout>
   );
 };

--- a/pages/create-password.tsx
+++ b/pages/create-password.tsx
@@ -45,4 +45,5 @@ const CreatePasswordPage = (): JSX.Element => {
     </Layout>
   );
 };
+
 export default CreatePasswordPage;

--- a/pages/create-password.tsx
+++ b/pages/create-password.tsx
@@ -8,6 +8,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Row } from "react-bootstrap";
 import { getProviderUserData } from "utils/auth-provider";
 import firebase from "firebase/app";
+import { LoaingPage } from "components/LoadingPage";
 
 const CreatePasswordPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
@@ -27,21 +28,28 @@ const CreatePasswordPage = (): JSX.Element => {
     }
   }, [authUser]);
 
+  if (
+    authUser == null ||
+    passwordUserData === undefined ||
+    passwordUserData != null
+  ) {
+    return <LoaingPage />;
+  }
+
   return (
     <Layout>
-      {authUser != null && passwordUserData === null && (
-        <React.Fragment>
-          <MyHead title="パスワード作成" />
-          <Row className="justify-content-center">
-            <UpdatePasswordForm onUpdated={() => Router.push("/profile")} />
-          </Row>
-          <Row className="justify-content-center">
-            <Link href="/profile">
-              <a>戻る</a>
-            </Link>
-          </Row>
-        </React.Fragment>
-      )}
+      <MyHead title="パスワード作成" />
+      <Row className="justify-content-center">
+        <UpdatePasswordForm
+          authUser={authUser}
+          onUpdated={() => Router.push("/profile")}
+        />
+      </Row>
+      <Row className="justify-content-center">
+        <Link href="/profile">
+          <a>戻る</a>
+        </Link>
+      </Row>
     </Layout>
   );
 };

--- a/pages/email-verify.tsx
+++ b/pages/email-verify.tsx
@@ -8,8 +8,10 @@ import { Button, Overlay, Row, Tooltip } from "react-bootstrap";
 
 const EmailVerifyPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
+
   const buttonRef = useRef(null);
   const [showTooltip, setShowTooltip] = useState(false);
+
   useEffect(() => {
     if (authUser === null) {
       Router.push("/login");
@@ -17,6 +19,7 @@ const EmailVerifyPage = (): JSX.Element => {
       Router.push("/");
     }
   }, [authUser]);
+
   const sendVerifyMail = async () => {
     if (authUser != null) {
       try {
@@ -29,6 +32,7 @@ const EmailVerifyPage = (): JSX.Element => {
       }
     }
   };
+
   return (
     <Layout>
       {authUser != null && (
@@ -72,4 +76,5 @@ const EmailVerifyPage = (): JSX.Element => {
     </Layout>
   );
 };
+
 export default EmailVerifyPage;

--- a/pages/email-verify.tsx
+++ b/pages/email-verify.tsx
@@ -1,9 +1,10 @@
 import { Layout } from "components/Layout";
+import { LoaingPage } from "components/LoadingPage";
 import { MyHead } from "components/MyHead";
 import { AuthContext } from "context/AuthContext";
 import Link from "next/link";
 import Router from "next/router";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { Button, Overlay, Row, Tooltip } from "react-bootstrap";
 
 const EmailVerifyPage = (): JSX.Element => {
@@ -33,46 +34,42 @@ const EmailVerifyPage = (): JSX.Element => {
     }
   };
 
+  if (authUser == null) {
+    return <LoaingPage />;
+  }
+
   return (
     <Layout>
-      {authUser != null && (
-        <React.Fragment>
-          <MyHead title="メールアドレス確認" />
-          <Row className="justify-content-center">
-            <h2>{authUser.email}に確認メールを送信しました</h2>
-          </Row>
-          <Row className="justify-content-center">
-            <h3>確認メール内のリンクをクリックして下さい</h3>
-          </Row>
-          <Row className="justify-content-center">
-            <Button
-              ref={buttonRef}
-              onClick={sendVerifyMail}
-              onBlur={() => {
-                setShowTooltip(false);
-              }}
-            >
-              確認メールを再送する
-            </Button>
-            <Overlay
-              target={buttonRef.current}
-              show={showTooltip}
-              placement="top"
-            >
-              {(props) => (
-                <Tooltip id="mail-sent-tooltip" {...props}>
-                  メールを送信しました！
-                </Tooltip>
-              )}
-            </Overlay>
-          </Row>
-          <Row className="justify-content-center">
-            <Link href="/profile">
-              <a>メールアドレスを変更する</a>
-            </Link>
-          </Row>
-        </React.Fragment>
-      )}
+      <MyHead title="メールアドレス確認" />
+      <Row className="justify-content-center">
+        <h2>{authUser.email}に確認メールを送信しました</h2>
+      </Row>
+      <Row className="justify-content-center">
+        <h3>確認メール内のリンクをクリックして下さい</h3>
+      </Row>
+      <Row className="justify-content-center">
+        <Button
+          ref={buttonRef}
+          onClick={sendVerifyMail}
+          onBlur={() => {
+            setShowTooltip(false);
+          }}
+        >
+          確認メールを再送する
+        </Button>
+        <Overlay target={buttonRef.current} show={showTooltip} placement="top">
+          {(props) => (
+            <Tooltip id="mail-sent-tooltip" {...props}>
+              メールを送信しました！
+            </Tooltip>
+          )}
+        </Overlay>
+      </Row>
+      <Row className="justify-content-center">
+        <Link href="/profile">
+          <a>メールアドレスを変更する</a>
+        </Link>
+      </Row>
     </Layout>
   );
 };

--- a/pages/groups/[groupId]/create-invitation.tsx
+++ b/pages/groups/[groupId]/create-invitation.tsx
@@ -1,55 +1,52 @@
-import { GetServerSideProps } from "next";
 import { Layout } from "../../../components/Layout";
 import { ErrorPage } from "../../../components/ErrorPage";
-import { GroupWithId, loadGroup } from "../../../interfaces/Group";
+import { loadGroup } from "../../../interfaces/Group";
 import { CreateInvitationForm } from "../../../components/CreateInvitationForm";
 import { useContext } from "react";
 import { AuthContext } from "../../../context/AuthContext";
 import { Row } from "react-bootstrap";
 import { MyHead } from "components/MyHead";
-import Router from "next/router";
+import Router, { useRouter } from "next/router";
 import React from "react";
 import Link from "next/link";
+import { useAsync } from "hooks/useAsync";
+import { isQueryString } from "utils/query";
+import { LoaingPage } from "components/LoadingPage";
 
-type Props = {
-  group?: GroupWithId;
-  errors?: string;
-};
+const CreateInvitationPage = (): JSX.Element => {
+  const router = useRouter();
+  const { groupId } = router.query;
 
-const CreateInvitationPage = ({ group, errors }: Props): JSX.Element => {
   const { authUser } = useContext(AuthContext);
 
-  if (errors) {
-    return <ErrorPage errorMessage={errors} />;
-  }
-  if (!group) {
-    return <ErrorPage />;
+  const group = useAsync(loadGroup, groupId, isQueryString);
+
+  if (group.data === undefined || authUser === undefined) {
+    return <LoaingPage />;
   }
 
-  if (authUser === undefined) {
-    return <React.Fragment />;
-  }
   if (
     authUser === null ||
-    group.members == null ||
-    !Object.keys(group.members).includes(authUser.uid)
+    group.data == null ||
+    group.data.members == null ||
+    !Object.keys(group.data.members).includes(authUser.uid)
   ) {
     return <ErrorPage errorMessage={"Invalid URL"} />;
   }
 
-  if (group.invitationId != null) {
-    Router.push(`/invitations/${group.invitationId}`);
-    return <ErrorPage />;
+  if (group.data.invitationId != null) {
+    Router.push(`/invitations/${group.data.invitationId}`);
+    return <LoaingPage />;
   }
 
   return (
     <Layout>
       <MyHead title="招待を作成" />
       <Row className="justify-content-center">
-        <CreateInvitationForm group={group} />
+        <CreateInvitationForm group={group.data} />
       </Row>
       <Row className="justify-content-center">
-        <Link href={`/groups/${group.id}`}>
+        <Link href={`/groups/${group.data.id}`}>
           <a>戻る</a>
         </Link>
       </Row>
@@ -58,22 +55,3 @@ const CreateInvitationPage = ({ group, errors }: Props): JSX.Element => {
 };
 
 export default CreateInvitationPage;
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { groupId } = context.query;
-  if (groupId == null || Array.isArray(groupId)) {
-    return { props: { errors: "Invalid URL" } };
-  } else {
-    try {
-      const group = await loadGroup(groupId);
-      if (group == null) {
-        return { props: { errors: "Invalid URL" } };
-      } else {
-        return { props: { group } };
-      }
-    } catch {
-      console.error("Unexpected Error");
-      return { props: { errors: "Unexpected Error" } };
-    }
-  }
-};

--- a/pages/groups/[groupId]/create-invitation.tsx
+++ b/pages/groups/[groupId]/create-invitation.tsx
@@ -10,7 +10,7 @@ import Router, { useRouter } from "next/router";
 import React from "react";
 import Link from "next/link";
 import { useAsync } from "hooks/useAsync";
-import { isQueryString } from "utils/query";
+import { isQueryString } from "utils/type-guard";
 import { LoaingPage } from "components/LoadingPage";
 
 const CreateInvitationPage = (): JSX.Element => {

--- a/pages/groups/[groupId]/create-invitation.tsx
+++ b/pages/groups/[groupId]/create-invitation.tsx
@@ -43,7 +43,7 @@ const CreateInvitationPage = (): JSX.Element => {
     <Layout>
       <MyHead title="招待を作成" />
       <Row className="justify-content-center">
-        <CreateInvitationForm group={group.data} />
+        <CreateInvitationForm authUser={authUser} group={group.data} />
       </Row>
       <Row className="justify-content-center">
         <Link href={`/groups/${group.data.id}`}>

--- a/pages/groups/[groupId]/index.tsx
+++ b/pages/groups/[groupId]/index.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { MyHead } from "components/MyHead";
 import { useRouter } from "next/router";
 import { useAsync } from "hooks/useAsync";
-import { isQueryString } from "utils/query";
+import { isQueryString } from "utils/type-guard";
 import { LoaingPage } from "components/LoadingPage";
 
 const GroupCalendarPage = (): JSX.Element => {

--- a/pages/groups/[groupId]/settings.tsx
+++ b/pages/groups/[groupId]/settings.tsx
@@ -36,7 +36,7 @@ const GroupSettingsPage = (): JSX.Element => {
 
   return (
     <Layout>
-      {group && (
+      {group != null && (
         <React.Fragment>
           <MyHead title="グループの設定" />
           <Row className="justify-content-center">

--- a/pages/groups/[groupId]/settings.tsx
+++ b/pages/groups/[groupId]/settings.tsx
@@ -1,7 +1,6 @@
-import { GetServerSideProps } from "next";
 import { Layout } from "../../../components/Layout";
 import { ErrorPage } from "../../../components/ErrorPage";
-import { GroupWithId, loadGroup } from "../../../interfaces/Group";
+import { loadGroup } from "../../../interfaces/Group";
 import { useContext } from "react";
 import { AuthContext } from "../../../context/AuthContext";
 import React from "react";
@@ -9,31 +8,28 @@ import { Row, Col } from "react-bootstrap";
 import Link from "next/link";
 import { UpdateGroupForm } from "components/UpdateGroupForm";
 import { MyHead } from "components/MyHead";
+import { LoaingPage } from "components/LoadingPage";
+import { useAsync } from "hooks/useAsync";
+import { isQueryString } from "utils/query";
+import { useRouter } from "next/router";
 
-type GroupSettingsPageProps = {
-  group?: GroupWithId;
-  errors?: string;
-};
+const GroupSettingsPage = (): JSX.Element => {
+  const router = useRouter();
+  const { groupId } = router.query;
 
-const GroupSettingsPage = ({
-  group,
-  errors,
-}: GroupSettingsPageProps): JSX.Element => {
   const { authUser } = useContext(AuthContext);
 
-  if (errors) {
-    return <ErrorPage errorMessage={errors} />;
+  const group = useAsync(loadGroup, groupId, isQueryString);
+
+  if (group.data === undefined || authUser === undefined) {
+    return <LoaingPage />;
   }
-  if (!group) {
-    return <ErrorPage />;
-  }
-  if (authUser === undefined) {
-    return <React.Fragment />;
-  }
+
   if (
     authUser === null ||
-    group.members == null ||
-    !Object.keys(group.members).includes(authUser.uid)
+    group.data == null ||
+    group.data.members == null ||
+    !Object.keys(group.data.members).includes(authUser.uid)
   ) {
     return <ErrorPage errorMessage={"Invalid URL"} />;
   }
@@ -44,7 +40,7 @@ const GroupSettingsPage = ({
         <React.Fragment>
           <MyHead title="グループの設定" />
           <Row className="justify-content-center">
-            <Link href={`/groups/${group.id}`}>
+            <Link href={`/groups/${group.data.id}`}>
               <a>戻る</a>
             </Link>
           </Row>
@@ -54,10 +50,10 @@ const GroupSettingsPage = ({
           <Row className="justify-content-center">
             <Col md={6}>
               <UpdateGroupForm
-                group={group}
+                group={group.data}
                 defaultValues={{
-                  name: group.name,
-                  description: group.description,
+                  name: group.data.name,
+                  description: group.data.description,
                 }}
               />
             </Col>
@@ -66,18 +62,18 @@ const GroupSettingsPage = ({
             <h2>グループへの招待</h2>
           </Row>
           <Row className="justify-content-center">
-            {group.invitationId && (
+            {group.data.invitationId && (
               <Link
                 href="/invitations/[invitationId]"
-                as={`/invitations/${group.invitationId}`}
+                as={`/invitations/${group.data.invitationId}`}
               >
                 <a>招待リンク確認</a>
               </Link>
             )}
-            {!group.invitationId && (
+            {!group.data.invitationId && (
               <Link
                 href="/groups/[groupId]/create-invitation"
-                as={`/groups/${group.id}/create-invitation`}
+                as={`/groups/${group.data.id}/create-invitation`}
               >
                 <a>招待リンク作成</a>
               </Link>
@@ -90,22 +86,3 @@ const GroupSettingsPage = ({
 };
 
 export default GroupSettingsPage;
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { groupId } = context.query;
-  if (groupId == null || Array.isArray(groupId)) {
-    return { props: { errors: "Invalid URL" } };
-  } else {
-    try {
-      const group = await loadGroup(groupId);
-      if (group == null || group.members == null) {
-        return { props: { errors: "Invalid URL" } };
-      } else {
-        return { props: { group } };
-      }
-    } catch {
-      console.error("Unexpected Error");
-      return { props: { errors: "Unexpected Error" } };
-    }
-  }
-};

--- a/pages/groups/[groupId]/settings.tsx
+++ b/pages/groups/[groupId]/settings.tsx
@@ -10,7 +10,7 @@ import { UpdateGroupForm } from "components/UpdateGroupForm";
 import { MyHead } from "components/MyHead";
 import { LoaingPage } from "components/LoadingPage";
 import { useAsync } from "hooks/useAsync";
-import { isQueryString } from "utils/query";
+import { isQueryString } from "utils/type-guard";
 import { useRouter } from "next/router";
 
 const GroupSettingsPage = (): JSX.Element => {

--- a/pages/invitations/[invitationId].tsx
+++ b/pages/invitations/[invitationId].tsx
@@ -11,7 +11,7 @@ import { Overlay, Row, Tooltip } from "react-bootstrap";
 import { MyHead } from "components/MyHead";
 import Link from "next/link";
 import { useAsync } from "hooks/useAsync";
-import { isQueryString } from "utils/query";
+import { isQueryString } from "utils/type-guard";
 import { LoaingPage } from "components/LoadingPage";
 
 const InvitationPage = (): JSX.Element => {

--- a/pages/invitations/[invitationId].tsx
+++ b/pages/invitations/[invitationId].tsx
@@ -32,12 +32,9 @@ const InvitationPage = (): JSX.Element => {
     return <LoaingPage />;
   }
 
-  if (invitationAndGroup.data === null) {
-    return <ErrorPage errorMessage={"Invalid URL"} />;
-  }
-
   if (
     authUser === null ||
+    invitationAndGroup.data === null ||
     invitationAndGroup.data.group.members == null ||
     !Object.keys(invitationAndGroup.data.group.members).includes(authUser.uid)
   ) {

--- a/pages/join/[invitationId].tsx
+++ b/pages/join/[invitationId].tsx
@@ -7,6 +7,8 @@ import { AuthContext } from "context/AuthContext";
 import Router, { useRouter } from "next/router";
 import { MyHead } from "components/MyHead";
 import { useAsync } from "../../hooks/useAsync";
+import { LoaingPage } from "components/LoadingPage";
+import { isQueryString } from "utils/query";
 
 const JoinGroupPage = (): JSX.Element => {
   const router = useRouter();
@@ -20,14 +22,13 @@ const JoinGroupPage = (): JSX.Element => {
     }
   }, [authUser]);
 
-  const group = useAsync(loadInvitationGroup, invitationId);
-  console.log(group.data);
+  const group = useAsync(loadInvitationGroup, invitationId, isQueryString);
 
-  if (
-    invitationId == null ||
-    Array.isArray(invitationId) ||
-    group.data == null
-  ) {
+  if (group.data === undefined) {
+    return <LoaingPage />;
+  }
+
+  if (group.data === null) {
     return <ErrorPage errorMessage={"Invalid URL"} />;
   }
 

--- a/pages/join/[invitationId].tsx
+++ b/pages/join/[invitationId].tsx
@@ -24,7 +24,11 @@ const JoinGroupPage = (): JSX.Element => {
 
   const group = useAsync(loadInvitationGroup, invitationId, isQueryString);
 
-  if (group.data === undefined) {
+  if (
+    group.data === undefined ||
+    authUser === undefined ||
+    (authUser != null && !authUser.emailVerified)
+  ) {
     return <LoaingPage />;
   }
 
@@ -34,13 +38,8 @@ const JoinGroupPage = (): JSX.Element => {
 
   return (
     <Layout>
-      {authUser !== undefined &&
-        !(authUser != null && !authUser.emailVerified) && (
-          <React.Fragment>
-            <MyHead title={`${group.data.name}に参加`} />
-            <JoinGroupForm group={group.data} />
-          </React.Fragment>
-        )}
+      <MyHead title={`${group.data.name}に参加`} />
+      <JoinGroupForm group={group.data} />
     </Layout>
   );
 };

--- a/pages/join/[invitationId].tsx
+++ b/pages/join/[invitationId].tsx
@@ -1,5 +1,5 @@
 import { ErrorPage } from "../../components/ErrorPage";
-import { loadInvitationGroup } from "../../interfaces/Invitation";
+import { loadInvitationAndGroup } from "../../interfaces/Invitation";
 import React, { useContext, useEffect } from "react";
 import { JoinGroupForm } from "../../components/JoinGroupForm";
 import { Layout } from "components/Layout";
@@ -22,24 +22,28 @@ const JoinGroupPage = (): JSX.Element => {
     }
   }, [authUser]);
 
-  const group = useAsync(loadInvitationGroup, invitationId, isQueryString);
+  const invitationAndGroup = useAsync(
+    loadInvitationAndGroup,
+    invitationId,
+    isQueryString
+  );
 
   if (
-    group.data === undefined ||
+    invitationAndGroup.data === undefined ||
     authUser === undefined ||
     (authUser != null && !authUser.emailVerified)
   ) {
     return <LoaingPage />;
   }
 
-  if (group.data === null) {
+  if (invitationAndGroup.data === null) {
     return <ErrorPage errorMessage={"Invalid URL"} />;
   }
 
   return (
     <Layout>
-      <MyHead title={`${group.data.name}に参加`} />
-      <JoinGroupForm group={group.data} />
+      <MyHead title={`${invitationAndGroup.data.group.name}に参加`} />
+      <JoinGroupForm group={invitationAndGroup.data.group} />
     </Layout>
   );
 };

--- a/pages/join/[invitationId].tsx
+++ b/pages/join/[invitationId].tsx
@@ -8,7 +8,8 @@ import Router, { useRouter } from "next/router";
 import { MyHead } from "components/MyHead";
 import { useAsync } from "../../hooks/useAsync";
 import { LoaingPage } from "components/LoadingPage";
-import { isQueryString } from "utils/query";
+import { isQueryString, isUidString } from "utils/type-guard";
+import { loadUser } from "interfaces/User";
 
 const JoinGroupPage = (): JSX.Element => {
   const router = useRouter();
@@ -28,6 +29,8 @@ const JoinGroupPage = (): JSX.Element => {
     isQueryString
   );
 
+  const user = useAsync(loadUser, authUser?.uid, isUidString);
+
   if (
     invitationAndGroup.data === undefined ||
     authUser === undefined ||
@@ -43,7 +46,11 @@ const JoinGroupPage = (): JSX.Element => {
   return (
     <Layout>
       <MyHead title={`${invitationAndGroup.data.group.name}に参加`} />
-      <JoinGroupForm group={invitationAndGroup.data.group} />
+      <JoinGroupForm
+        authUser={authUser}
+        user={user.data}
+        group={invitationAndGroup.data.group}
+      />
     </Layout>
   );
 };

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -20,7 +20,7 @@ const LoginPage = (): JSX.Element => {
     }
   }, [authUser]);
 
-  if (authUser === undefined || authUser != null) {
+  if (authUser !== null) {
     return <LoaingPage />;
   }
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -8,6 +8,7 @@ import { Layout } from "../components/Layout";
 import { LoginForm } from "../components/LoginForm";
 import { AuthContext } from "../context/AuthContext";
 import { GoogleLoginButton } from "components/GoogleLoginButton";
+import { LoaingPage } from "components/LoadingPage";
 
 const LoginPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
@@ -19,65 +20,65 @@ const LoginPage = (): JSX.Element => {
     }
   }, [authUser]);
 
+  if (authUser === undefined || authUser != null) {
+    return <LoaingPage />;
+  }
+
   return (
     <Layout>
-      {authUser === null && (
+      {showResetPasswordForm && (
         <React.Fragment>
-          {showResetPasswordForm && (
-            <React.Fragment>
-              <MyHead title="パスワードをリセット" />
-              <Row className="justify-content-center">
-                <h1>パスワードの再設定</h1>
-              </Row>
-              <Row className="justify-content-center mt-2">
-                <SendResetPasswordMailForm />
-              </Row>
-              <Row className="justify-content-center mt-2">
-                <a
-                  href="#"
-                  onClick={() => {
-                    setShowResetPasswordForm(false);
-                  }}
-                >
-                  戻る
-                </a>
-              </Row>
-            </React.Fragment>
-          )}
-          {!showResetPasswordForm && (
-            <React.Fragment>
-              <MyHead title="ログイン" />
-              <Row className="justify-content-center">
-                <h1>ログイン</h1>
-              </Row>
-              <Row className="justify-content-center">
-                <p>またはGoogleアカウントでログイン</p>
-              </Row>
-              <Row className="justify-content-center">
-                <GoogleLoginButton />
-              </Row>
-              <Row className="justify-content-center">
-                <LoginForm onLogined={() => Router.push("/")} />
-              </Row>
-              <Row className="justify-content-center mt-2">
-                <p>まだ登録していませんか?</p>
-                <Link href="/register">
-                  <a>登録</a>
-                </Link>
-              </Row>
-              <Row className="justify-content-center mt-2">
-                <p>パスワードを忘れた場合: </p>
-                <a
-                  href="#"
-                  onClick={() => {
-                    setShowResetPasswordForm(true);
-                  }}
-                >
-                  再設定する
-                </a>
-              </Row>
-            </React.Fragment>
-          )}
+          <MyHead title="パスワードをリセット" />
+          <Row className="justify-content-center">
+            <h1>パスワードの再設定</h1>
+          </Row>
+          <Row className="justify-content-center mt-2">
+            <SendResetPasswordMailForm />
+          </Row>
+          <Row className="justify-content-center mt-2">
+            <a
+              href="#"
+              onClick={() => {
+                setShowResetPasswordForm(false);
+              }}
+            >
+              戻る
+            </a>
+          </Row>
+        </React.Fragment>
+      )}
+      {!showResetPasswordForm && (
+        <React.Fragment>
+          <MyHead title="ログイン" />
+          <Row className="justify-content-center">
+            <h1>ログイン</h1>
+          </Row>
+          <Row className="justify-content-center">
+            <p>またはGoogleアカウントでログイン</p>
+          </Row>
+          <Row className="justify-content-center">
+            <GoogleLoginButton />
+          </Row>
+          <Row className="justify-content-center">
+            <LoginForm authUser={authUser} onLogined={() => Router.push("/")} />
+          </Row>
+          <Row className="justify-content-center mt-2">
+            <p>まだ登録していませんか?</p>
+            <Link href="/register">
+              <a>登録</a>
+            </Link>
+          </Row>
+          <Row className="justify-content-center mt-2">
+            <p>パスワードを忘れた場合: </p>
+            <a
+              href="#"
+              onClick={() => {
+                setShowResetPasswordForm(true);
+              }}
+            >
+              再設定する
+            </a>
+          </Row>
         </React.Fragment>
       )}
     </Layout>

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -4,6 +4,7 @@ import Obfuscate from "react-obfuscate";
 
 const PrivacyPolicyPage = (): JSX.Element => {
   const url = typeof window !== "undefined" ? document.location.origin : "";
+
   return (
     <Layout>
       <MyHead title="プライバシーポリシー" />
@@ -40,4 +41,5 @@ const PrivacyPolicyPage = (): JSX.Element => {
     </Layout>
   );
 };
+
 export default PrivacyPolicyPage;

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -176,6 +176,7 @@ const ProfilePage = (): JSX.Element => {
             <Row className="justify-content-center">
               {passwordUserData != null && (
                 <LoginForm
+                  authUser={authUser}
                   onLogined={() => {
                     if (onLoginedAction == "updateEmail") {
                       setReadyUpdateEmail(true);

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -131,6 +131,7 @@ const ProfilePage = (): JSX.Element => {
           <MyHead title="パスワード更新" />
           <Row className="justify-content-center">
             <UpdatePasswordForm
+              authUser={authUser}
               onUpdated={() => {
                 setReadyUpdatePassword(false);
                 setUpdated("updatePassword");

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -237,6 +237,7 @@ const ProfilePage = (): JSX.Element => {
           <Row className="justify-content-center">
             <Col md={6}>
               <UpdateUserForm
+                authUser={authUser}
                 user={userAndGroups.data.user}
                 defaultValues={{
                   name: userAndGroups.data.user.name,

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -146,6 +146,7 @@ const ProfilePage = (): JSX.Element => {
           </Row>
           <Row className="justify-content-center">
             <DeleteUserButton
+              authUser={authUser}
               user={userAndGroups.data.user}
               onDeleted={() => {
                 Router.push("/");

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -117,6 +117,7 @@ const ProfilePage = (): JSX.Element => {
           <MyHead title="メールアドレス更新" />
           <Row className="justify-content-center">
             <UpdateEmailForm
+              authUser={authUser}
               onUpdated={() => {
                 setReadyUpdateEmail(false);
                 setUpdated("updateEmail");

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -10,8 +10,8 @@ import React, { useEffect, useContext, useState } from "react";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import { Layout } from "../components/Layout";
 import { AuthContext } from "../context/AuthContext";
-import { GroupWithId, loadGroup } from "../interfaces/Group";
-import { loadUser, UserWithId } from "../interfaces/User";
+import { GroupWithId } from "../interfaces/Group";
+import { loadUserAndGroups } from "../interfaces/User";
 import { MyHead } from "components/MyHead";
 import firebase from "firebase/app";
 import {
@@ -19,11 +19,20 @@ import {
   linkWithGoogle,
   loginWithGoogle,
 } from "utils/auth-provider";
+import { useAsync } from "hooks/useAsync";
+import { isUidString } from "utils/type-guard";
+import { LoaingPage } from "components/LoadingPage";
+import { ErrorPage } from "components/ErrorPage";
 
 const ProfilePage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
-  const [user, setUser] = useState<UserWithId | undefined>(undefined);
-  const [groups, setGroups] = useState<GroupWithId[] | undefined>(undefined);
+
+  const userAndGroups = useAsync(loadUserAndGroups, authUser?.uid, isUidString);
+
+  const [groups, setGroups] = useState<GroupWithId[] | null | undefined>(
+    undefined
+  );
+
   const [onLoginedAction, setOnLoginedAction] = useState<
     | "updateEmail"
     | "updatePassword"
@@ -44,60 +53,36 @@ const ProfilePage = (): JSX.Element => {
     firebase.UserInfo | undefined | null
   >(undefined);
 
-  // TODO よく使う処理なのでカスタムフックにする
   useEffect(() => {
-    // コンポーネントが削除された後にsetDateStatusListが呼ばれないようにするため
-    let unmounted = false;
-    const setFromDatabase = async () => {
-      if (authUser === null) {
-        Router.push("/login");
-      } else if (authUser != null) {
-        setPasswordUserData(getProviderUserData(authUser, "password"));
-        setGoogleUserData(getProviderUserData(authUser, "google.com"));
-        try {
-          const user = await loadUser(authUser.uid);
-          if (user != null && !unmounted) {
-            setUser(user);
-            const groupList: GroupWithId[] = [];
-            if (user.groups != null) {
-              const groupIds = Object.keys(user.groups);
-              const groupsfromDatabase = await Promise.all(
-                groupIds.map((groupId) => loadGroup(groupId))
-              );
-              for (const group of groupsfromDatabase) {
-                if (group != null) {
-                  groupList.push(group);
-                }
-              }
-            }
-            if (!unmounted) {
-              groupList.sort((a, b) => {
-                const nameA = a.name.toUpperCase();
-                const nameB = b.name.toUpperCase();
-                if (nameA < nameB) {
-                  return -1;
-                }
-                if (nameA > nameB) {
-                  return 1;
-                }
-                return 0;
-              });
-              setGroups(groupList);
-            }
-          }
-        } catch {
-          console.error("Unexpected Error");
-        }
-      }
-    };
-    if (authUser !== undefined) {
-      setFromDatabase();
+    if (authUser === null) {
+      Router.push("/login");
+    } else if (authUser != null) {
+      setPasswordUserData(getProviderUserData(authUser, "password"));
+      setGoogleUserData(getProviderUserData(authUser, "google.com"));
     }
-    const cleanup = () => {
-      unmounted = true;
-    };
-    return cleanup;
   }, [authUser]);
+
+  useEffect(() => {
+    if (userAndGroups.data === undefined) {
+      setGroups(undefined);
+    } else if (userAndGroups.data === null) {
+      setGroups(null);
+    } else {
+      setGroups(userAndGroups.data.groups);
+    }
+  }, [userAndGroups.data]);
+
+  if (
+    authUser == null ||
+    userAndGroups.data === undefined ||
+    groups === undefined
+  ) {
+    return <LoaingPage />;
+  }
+
+  if (userAndGroups.data === null || groups === null) {
+    return <ErrorPage />;
+  }
 
   return (
     <Layout>
@@ -127,7 +112,7 @@ const ProfilePage = (): JSX.Element => {
           </Row>
         </React.Fragment>
       )}
-      {readyUpdateEmail && user && (
+      {readyUpdateEmail && (
         <React.Fragment>
           <MyHead title="メールアドレス更新" />
           <Row className="justify-content-center">
@@ -140,7 +125,7 @@ const ProfilePage = (): JSX.Element => {
           </Row>
         </React.Fragment>
       )}
-      {readyUpdatePassword && user && (
+      {readyUpdatePassword && (
         <React.Fragment>
           <MyHead title="パスワード更新" />
           <Row className="justify-content-center">
@@ -153,15 +138,15 @@ const ProfilePage = (): JSX.Element => {
           </Row>
         </React.Fragment>
       )}
-      {readyDeleteUser && user && (
+      {readyDeleteUser && (
         <React.Fragment>
           <MyHead title="ユーザー削除" />
           <Row className="justify-content-center">
-            <h2>本当に{user.name}を削除しますか？</h2>
+            <h2>本当に{userAndGroups.data.user.name}を削除しますか？</h2>
           </Row>
           <Row className="justify-content-center">
             <DeleteUserButton
-              user={user}
+              user={userAndGroups.data.user}
               onDeleted={() => {
                 Router.push("/");
               }}
@@ -234,7 +219,7 @@ const ProfilePage = (): JSX.Element => {
             </Row>
           </React.Fragment>
         )}
-      {user && groups && onLoginedAction == null && (
+      {onLoginedAction == null && (
         <React.Fragment>
           <MyHead title="ユーザー情報" />
           <Row className="justify-content-center">
@@ -248,10 +233,10 @@ const ProfilePage = (): JSX.Element => {
           <Row className="justify-content-center">
             <Col md={6}>
               <UpdateUserForm
-                user={user}
+                user={userAndGroups.data.user}
                 defaultValues={{
-                  name: user.name,
-                  description: user.description,
+                  name: userAndGroups.data.user.name,
+                  description: userAndGroups.data.user.description,
                 }}
               />
             </Col>
@@ -261,7 +246,7 @@ const ProfilePage = (): JSX.Element => {
           </Row>
           <Row>
             <GroupListForm
-              user={user}
+              user={userAndGroups.data.user}
               groups={groups}
               setGroups={(g: GroupWithId[]) => setGroups(g)}
             />
@@ -269,83 +254,75 @@ const ProfilePage = (): JSX.Element => {
           <Row className="justify-content-center mt-3">
             <h2>Googleアカウント</h2>
           </Row>
-          {authUser != null &&
-            googleUserData == null &&
-            authUser.emailVerified && (
-              <React.Fragment>
-                <Row className="justify-content-center">
-                  <p>Googleアカウントとの連携にはログインが必要です</p>
-                </Row>
-                <Row className="justify-content-center">
-                  <Button
-                    variant="accent"
-                    type="button"
-                    onClick={() => setOnLoginedAction("linkWithGoogle")}
-                  >
-                    ログイン画面へ
-                  </Button>
-                </Row>
-              </React.Fragment>
-            )}
-          {authUser != null &&
-            googleUserData == null &&
-            !authUser.emailVerified && (
+          {googleUserData == null && authUser.emailVerified && (
+            <React.Fragment>
               <Row className="justify-content-center">
-                <p>
-                  Googleアカウントとの連携には
-                  <Link href="/email-verify">
-                    <a>メールアドレスの確認</a>
-                  </Link>
-                  が必要です
-                </p>
+                <p>Googleアカウントとの連携にはログインが必要です</p>
               </Row>
-            )}
-          {authUser != null &&
-            googleUserData != null &&
-            passwordUserData != null && (
-              <React.Fragment>
-                <Row className="justify-content-center">
-                  <p>Googleアカウントと連携しています</p>
-                </Row>
-                <Row className="justify-content-center">
-                  <Button
-                    variant="main"
-                    type="button"
-                    onClick={() => {
-                      authUser
-                        .unlink("google.com")
-                        .then(() => {
-                          Router.reload();
-                        })
-                        .catch(() => {
-                          console.error("Unexpected Error");
-                        });
-                    }}
-                  >
-                    Googleアカウントとの連携を解除
-                  </Button>
-                </Row>
-              </React.Fragment>
-            )}
-          {authUser != null &&
-            googleUserData != null &&
-            passwordUserData == null && (
               <Row className="justify-content-center">
-                <p>
-                  Googleアカウントとの連携を解除するには
-                  <a
-                    href="#"
-                    onClick={() => {
-                      window.history.replaceState(null, "", "/create-password");
-                      loginWithGoogle();
-                    }}
-                  >
-                    パスワードの設定
-                  </a>
-                  が必要です
-                </p>
+                <Button
+                  variant="accent"
+                  type="button"
+                  onClick={() => setOnLoginedAction("linkWithGoogle")}
+                >
+                  ログイン画面へ
+                </Button>
               </Row>
-            )}
+            </React.Fragment>
+          )}
+          {googleUserData == null && !authUser.emailVerified && (
+            <Row className="justify-content-center">
+              <p>
+                Googleアカウントとの連携には
+                <Link href="/email-verify">
+                  <a>メールアドレスの確認</a>
+                </Link>
+                が必要です
+              </p>
+            </Row>
+          )}
+          {googleUserData != null && passwordUserData != null && (
+            <React.Fragment>
+              <Row className="justify-content-center">
+                <p>Googleアカウントと連携しています</p>
+              </Row>
+              <Row className="justify-content-center">
+                <Button
+                  variant="main"
+                  type="button"
+                  onClick={() => {
+                    authUser
+                      .unlink("google.com")
+                      .then(() => {
+                        Router.reload();
+                      })
+                      .catch(() => {
+                        console.error("Unexpected Error");
+                      });
+                  }}
+                >
+                  Googleアカウントとの連携を解除
+                </Button>
+              </Row>
+            </React.Fragment>
+          )}
+          {googleUserData != null && passwordUserData == null && (
+            <Row className="justify-content-center">
+              <p>
+                Googleアカウントとの連携を解除するには
+                <a
+                  href="#"
+                  onClick={() => {
+                    window.history.replaceState(null, "", "/create-password");
+                    loginWithGoogle();
+                  }}
+                >
+                  パスワードの設定
+                </a>
+                が必要です
+              </p>
+            </Row>
+          )}
           <Row className="justify-content-center mt-3">
             <h2>メールアドレス</h2>
           </Row>
@@ -355,16 +332,12 @@ const ProfilePage = (): JSX.Element => {
           <Row className="justify-content-center">
             <Col md={6}>
               <Form.Control
-                value={
-                  authUser != null && authUser.email != null
-                    ? authUser.email
-                    : ""
-                }
+                value={authUser.email != null ? authUser.email : ""}
                 readOnly
               />
             </Col>
           </Row>
-          {authUser != null && !authUser.emailVerified && (
+          {!authUser.emailVerified && (
             <Row className="justify-content-center">
               <Form.Text>
                 メールアドレスが未確認です！

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,12 +1,13 @@
 import { MyHead } from "components/MyHead";
 import Link from "next/link";
 import Router from "next/router";
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext } from "react";
 import { Row } from "react-bootstrap";
 import { Layout } from "../components/Layout";
 import { RegisterForm } from "../components/RegisterForm";
 import { AuthContext } from "../context/AuthContext";
 import { GoogleLoginButton } from "components/GoogleLoginButton";
+import { LoaingPage } from "components/LoadingPage";
 
 const RegisterPage = (): JSX.Element => {
   const { authUser } = useContext(AuthContext);
@@ -17,31 +18,31 @@ const RegisterPage = (): JSX.Element => {
     }
   }, [authUser]);
 
+  if (authUser !== null) {
+    return <LoaingPage />;
+  }
+
   return (
     <Layout>
-      {authUser === null && (
-        <React.Fragment>
-          <MyHead title="アカウント作成" />
-          <Row className="justify-content-center">
-            <h1>アカウント作成</h1>
-          </Row>
-          <Row className="justify-content-center">
-            <p>またはGoogleアカウントでログイン</p>
-          </Row>
-          <Row className="justify-content-center">
-            <GoogleLoginButton />
-          </Row>
-          <Row className="justify-content-center">
-            <RegisterForm onRegistered={() => Router.push("/email-verify")} />
-          </Row>
-          <Row className="justify-content-center">
-            <p>アカウントをお持ちですか？</p>
-            <Link href="/login">
-              <a>ログイン</a>
-            </Link>
-          </Row>
-        </React.Fragment>
-      )}
+      <MyHead title="アカウント作成" />
+      <Row className="justify-content-center">
+        <h1>アカウント作成</h1>
+      </Row>
+      <Row className="justify-content-center">
+        <p>またはGoogleアカウントでログイン</p>
+      </Row>
+      <Row className="justify-content-center">
+        <GoogleLoginButton />
+      </Row>
+      <Row className="justify-content-center">
+        <RegisterForm onRegistered={() => Router.push("/email-verify")} />
+      </Row>
+      <Row className="justify-content-center">
+        <p>アカウントをお持ちですか？</p>
+        <Link href="/login">
+          <a>ログイン</a>
+        </Link>
+      </Row>
     </Layout>
   );
 };

--- a/styles/sass/calendar.scss
+++ b/styles/sass/calendar.scss
@@ -61,32 +61,32 @@
 
 // Set free day's text color to accent color
 
-.calendar-free {
+.calendar-free:not(:disabled) {
   background-color: $accent-color !important;
   color: #ffffff !important;
 }
 
-.calendar-free:hover {
+.calendar-free:hover:not(:disabled) {
   background-color: $accent-dark-color !important;
 }
 
-.calendar-light-free {
+.calendar-light-free:not(:disabled) {
   background-color: $accent-light-color !important;
   color: #ffffff !important;
 }
 
-.calendar-light-free:hover {
+.calendar-light-free:hover:not(:disabled) {
   background-color: $accent-dark-color !important;
 }
 
 // Set busy day's text color to may color
 
-.calendar-busy {
+.calendar-busy:not(:disabled) {
   background-color: $main-color !important;
   color: #ffffff !important;
 }
 
-.calendar-busy:hover {
+.calendar-busy:hover:not(:disabled) {
   background-color: $main-dark-color !important;
 }
 

--- a/styles/sass/calendar.scss
+++ b/styles/sass/calendar.scss
@@ -38,12 +38,16 @@
 // Set Saturday's text color to blue expect disable day
 // Set Sunday's text color to red expect disable day
 
-.react-calendar__tile:nth-child(7n-1):not(.calendar-free):not(.calendar-busy):not(.react-calendar__month-view__days__day--neighboringMonth) {
+.react-calendar__tile:nth-child(7n-1):not(.calendar-free):not(.calendar-busy):not(.react-calendar__month-view__days__day--neighboringMonth):not(:disabled) {
   color: #0000ff !important;
 }
 
-.react-calendar__tile:nth-child(7n):not(.calendar-free):not(.calendar-busy):not(.react-calendar__month-view__days__day--neighboringMonth) {
+.react-calendar__tile:nth-child(7n):not(.calendar-free):not(.calendar-busy):not(.react-calendar__month-view__days__day--neighboringMonth):not(:disabled) {
   color: #ff0000 !important;
+}
+
+.react-calendar__tile:disabled:not(.react-calendar__month-view__days__day--neighboringMonth) {
+  color: #1010104d !important;
 }
 
 .react-calendar__month-view__days__day--neighboringMonth {

--- a/types/react-obfuscate/index.d.ts
+++ b/types/react-obfuscate/index.d.ts
@@ -1,11 +1,11 @@
-interface headersType {
+type headersType = {
   cc: string;
   bcc: string;
   subject: string;
   body: string;
-}
+};
 
-interface ObfuscateProps {
+type ObfuscateProps = {
   email?: string | null;
   headers?: headersType | null;
   tel?: string | null;
@@ -17,7 +17,7 @@ interface ObfuscateProps {
   obfuscateChildren?: boolean;
   element?: string;
   onClick?: function;
-}
+};
 
 export default function Obfuscate({
   email = null,

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -1,6 +1,0 @@
-export const isQueryString = (
-  arg: string | string[] | undefined
-): arg is string => {
-  if (arg == null || Array.isArray(arg)) return false;
-  return true;
-};

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -1,0 +1,6 @@
+export const isQueryString = (
+  arg: string | string[] | undefined
+): arg is string => {
+  if (arg == null || Array.isArray(arg)) return false;
+  return true;
+};

--- a/utils/type-guard.ts
+++ b/utils/type-guard.ts
@@ -1,0 +1,10 @@
+export const isQueryString = (
+  query: string | string[] | undefined
+): query is string => {
+  if (query == null || Array.isArray(query)) return false;
+  return true;
+};
+
+export const isUidString = (uid: string | null | undefined): uid is string => {
+  return uid != null;
+};


### PR DESCRIPTION
# 概要

- firebase realtime database のデータ取得をSSRで行うとキャッシュが効かず遅いのでCSRに統一した
  - データ取得を行うカスタムフックを作成
- authUserを極力ContextからでなくPropsから取得するように変更
  - 余計なnullチェックを省くため
- ローディング中画面を作成
- 型定義のほとんどをinterfaceではなくtypeに統一した
